### PR TITLE
Setup Mailgun

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,9 +64,20 @@ Rails.application.configure do
 
   config.action_mailer.asset_host = ENV.fetch('MAILER_DEFAULT_HOST')
 
-  config.action_mailer.default_url_options = { 
-    host: ENV.fetch('MAILER_DEFAULT_HOST'), 
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch('MAILER_DEFAULT_HOST'),
     port: ENV.fetch('MAILER_DEFAULT_PORT')
+  }
+
+  config.action_mailer.delivery_method = :smtp
+
+  config.action_mailer.smtp_settings = {
+    port: ENV.fetch('MAILGUN_SMTP_PORT'),
+    address: ENV.fetch('MAILGUN_SMTP_SERVER'),
+    user_name: ENV.fetch('MAILGUN_SMTP_LOGIN'),
+    password: ENV.fetch('MAILGUN_SMTP_PASSWORD'),
+    domain: ENV.fetch('APP_DOMAIN'),
+    authentication: :plain,
   }
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = "no-reply@#{ENV.fetch('APP_DOMAIN', ENV.fetch('MAILER_DEFAULT_HOST'))}"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
## What happened
Setup Mailgun on production

 
## Insight
- Run `heroku addons:create mailgun:starter` to install Mailgun on Heroku
- I can't install Sendgrid on my account, so I change to use Mailgun. I got this error when installing: `An error was encountered when contacting the add-on partner to create sendgrid:starter: Error Provisioning User - Whitelabel domain could not be located when creating customer`
- Follow [this docs](https://devcenter.heroku.com/articles/mailgun#sending-emails-via-smtp)
 

## Proof Of Work
N/A
 