### PR TITLE
As an API user, I can submit my survey response

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -10,6 +10,20 @@ module API
       def current_user
         User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
       end
+
+      # Render Error Message in json_api format
+      def render_error(detail:, source: nil, meta: nil, status: :unprocessable_entity, code: nil)
+        errors = [
+          {
+            source: source,
+            detail: detail,
+            code: code,
+            meta: meta
+          }.compact
+        ]
+
+        render json: { errors: errors }, status: status
+      end
     end
   end
 end

--- a/app/controllers/api/v1/responses_controller.rb
+++ b/app/controllers/api/v1/responses_controller.rb
@@ -4,7 +4,7 @@ module API
   module V1
     class ResponsesController < ApplicationController
       def create
-        response_form = ResponseForm.new(create_params)
+        response_form = ResponseForm.new(create_params.to_h)
 
         if response_form.save
           render status: :created
@@ -18,9 +18,7 @@ module API
       def create_params
         params
           .require(:response)
-          .permit(questions: [:id, { answers: %i[id answer] }])
-          .to_h
-          .merge(survey_id: params[:survey_id])
+          .permit(:survey_id, questions: [:id, { answers: %i[id answer] }])
       end
     end
   end

--- a/app/controllers/api/v1/responses_controller.rb
+++ b/app/controllers/api/v1/responses_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    class ResponsesController < ApplicationController
+      def create
+        response_form = ResponseForm.new(create_params)
+
+        if response_form.save
+          render status: :created
+        else
+          render_error(detail: response_form.errors.full_messages.to_sentence)
+        end
+      end
+
+      private
+
+      def create_params
+        params
+          .require(:response)
+          .permit(questions: [:id, { answers: %i[id answer] }])
+          .to_h
+          .merge(survey_id: params[:survey_id])
+      end
+    end
+  end
+end

--- a/app/forms/application_form.rb
+++ b/app/forms/application_form.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class ApplicationForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+end

--- a/app/forms/response_form.rb
+++ b/app/forms/response_form.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class ResponseForm < ApplicationForm
+  attr_reader :survey, :questions
+
+  validates :survey, presence: { message: :invalid }
+  validates :questions, presence: true
+  validate :validate_questions, if: -> { survey }
+
+  def initialize(params = {})
+    @survey = Survey.find_by(id: params[:survey_id])
+    @questions = params[:questions]
+  end
+
+  # @return [Boolean]
+  def save
+    valid?
+  end
+
+  private
+
+  # Check if all submitted questions are contained in survey questions
+  def validate_questions
+    survey_questions_ids = survey.questions.map(&:id)
+    questions_ids = questions.map { |question| question.symbolize_keys[:id] }
+
+    return if (survey_questions_ids & questions_ids) == questions_ids
+
+    errors.add(:questions, :invalid)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,10 +18,8 @@ Rails.application.routes.draw do
         resources :passwords, only: :create
       end
 
-      resources :surveys, only: %i[index show] do
-        resources :responses, only: :create
-      end
-
+      resources :responses, only: :create
+      resources :surveys, only: %i[index show]
       resource :users, only: :show, path: :me
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,10 @@ Rails.application.routes.draw do
         resources :passwords, only: :create
       end
 
-      resources :surveys, only: %i[index show]
+      resources :surveys, only: %i[index show] do
+        resources :responses, only: :create
+      end
+
       resource :users, only: :show, path: :me
     end
   end

--- a/spec/controllers/api/v1/responses_controller_spec.rb
+++ b/spec/controllers/api/v1/responses_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe API::V1::ResponsesController, type: :controller do
       end
     end
 
-    context 'given an empty questions' do
+    context 'given no questions' do
       it 'returns unprocessable_entity status' do
         post :create, params: { survey_id: 'd5de6a8f8f5f1cfe51bc', questions: [] }
 
@@ -55,7 +55,7 @@ RSpec.describe API::V1::ResponsesController, type: :controller do
       end
     end
 
-    context 'given questions that has invalid question IDs' do
+    context 'given questions with invalid question IDs' do
       it 'returns unprocessable_entity status' do
         questions_ids = [
           { id: 'invalid' }

--- a/spec/controllers/api/v1/responses_controller_spec.rb
+++ b/spec/controllers/api/v1/responses_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe API::V1::ResponsesController, type: :controller do
+  describe 'POST#create', auth: :user_token do
+    context 'given a valid survey ID' do
+      it 'returns created status' do
+        questions_ids = [
+          { id: '940d229e4cd87cd1e202' },
+          { id: 'c3a9b8ce5c2356010703' }
+        ]
+        post :create, params: { survey_id: 'd5de6a8f8f5f1cfe51bc', response: { questions: questions_ids } }
+
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context 'given an invalid survey ID' do
+      it 'returns unprocessable_entity status' do
+        questions_ids = [
+          { id: '940d229e4cd87cd1e202' },
+          { id: 'c3a9b8ce5c2356010703' }
+        ]
+        post :create, params: { survey_id: 'invalid', response: { questions: questions_ids } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'has errors' do
+        post :create, params: { survey_id: 'invalid', response: { questions: [] } }
+
+        response_body = JSON.parse(response.body, symbolize_names: true)
+        expect(response_body[:errors]).to include(detail: "Survey is invalid and Questions can't be blank")
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/responses_controller_spec.rb
+++ b/spec/controllers/api/v1/responses_controller_spec.rb
@@ -7,10 +7,11 @@ RSpec.describe API::V1::ResponsesController, type: :controller do
     context 'given a valid survey ID' do
       it 'returns created status' do
         questions_ids = [
-          { id: '940d229e4cd87cd1e202' },
-          { id: 'c3a9b8ce5c2356010703' }
+          { id: '940d229e4cd87cd1e202', answers: [{ id: '037574cb93d16800eecd' }] },
+          { id: 'c3a9b8ce5c2356010703', answers: [{ id: '2a49e148c5b170aca804', answer: 'My answer' }] }
         ]
-        post :create, params: { survey_id: 'd5de6a8f8f5f1cfe51bc', response: { questions: questions_ids } }
+
+        post :create, params: { survey_id: 'd5de6a8f8f5f1cfe51bc', questions: questions_ids }
 
         expect(response).to have_http_status(:created)
       end
@@ -19,19 +20,61 @@ RSpec.describe API::V1::ResponsesController, type: :controller do
     context 'given an invalid survey ID' do
       it 'returns unprocessable_entity status' do
         questions_ids = [
-          { id: '940d229e4cd87cd1e202' },
-          { id: 'c3a9b8ce5c2356010703' }
+          { id: '940d229e4cd87cd1e202' }
         ]
-        post :create, params: { survey_id: 'invalid', response: { questions: questions_ids } }
+
+        post :create, params: { survey_id: 'invalid', questions: questions_ids }
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
       it 'has errors' do
-        post :create, params: { survey_id: 'invalid', response: { questions: [] } }
+        questions_ids = [
+          { id: '940d229e4cd87cd1e202' }
+        ]
+
+        post :create, params: { survey_id: 'invalid', questions: questions_ids }
 
         response_body = JSON.parse(response.body, symbolize_names: true)
-        expect(response_body[:errors]).to include(detail: "Survey is invalid and Questions can't be blank")
+        expect(response_body[:errors]).to include(detail: 'Survey is invalid')
+      end
+    end
+
+    context 'given an empty questions' do
+      it 'returns unprocessable_entity status' do
+        post :create, params: { survey_id: 'd5de6a8f8f5f1cfe51bc', questions: [] }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'has errors' do
+        post :create, params: { survey_id: 'd5de6a8f8f5f1cfe51bc', questions: [] }
+
+        response_body = JSON.parse(response.body, symbolize_names: true)
+        expect(response_body[:errors]).to include(detail: "Questions can't be blank")
+      end
+    end
+
+    context 'given questions that has invalid question IDs' do
+      it 'returns unprocessable_entity status' do
+        questions_ids = [
+          { id: 'invalid' }
+        ]
+
+        post :create, params: { survey_id: 'd5de6a8f8f5f1cfe51bc', questions: questions_ids }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'has errors' do
+        questions_ids = [
+          { id: 'invalid' }
+        ]
+
+        post :create, params: { survey_id: 'd5de6a8f8f5f1cfe51bc', questions: questions_ids }
+
+        response_body = JSON.parse(response.body, symbolize_names: true)
+        expect(response_body[:errors]).to include(detail: 'Questions is invalid')
       end
     end
   end

--- a/spec/forms/response_form_spec.rb
+++ b/spec/forms/response_form_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ResponseForm do
+  describe '#save' do
+    context 'given valid attributes' do
+      it 'returns true' do
+        questions_ids = [
+          { id: '940d229e4cd87cd1e202' },
+          { id: 'c3a9b8ce5c2356010703' }
+        ]
+        form = described_class.new(survey_id: 'd5de6a8f8f5f1cfe51bc', questions: questions_ids)
+
+        expect(form.save).to eq(true)
+      end
+
+      it 'does NOT have errors' do
+        questions_ids = [
+          { id: '940d229e4cd87cd1e202' },
+          { id: 'c3a9b8ce5c2356010703' }
+        ]
+        form = described_class.new(survey_id: 'd5de6a8f8f5f1cfe51bc', questions: questions_ids)
+        form.save
+
+        expect(form.errors).to be_empty
+      end
+    end
+
+    context 'given invalid attributes' do
+      context 'given an invalid survey ID' do
+        it 'returns false' do
+          form = described_class.new(survey_id: 'invalid')
+
+          expect(form.save).to eq(false)
+        end
+
+        it 'has error messages' do
+          form = described_class.new(survey_id: 'invalid')
+          form.save
+
+          expect(form.errors.messages[:survey]).to include('is invalid')
+        end
+      end
+
+      context 'given invalid questions IDs' do
+        it 'returns false' do
+          questions_ids = [
+            { id: 'invalid' }
+          ]
+          form = described_class.new(survey_id: 'd5de6a8f8f5f1cfe51bc', questions: questions_ids)
+
+          expect(form.save).to eq(false)
+        end
+
+        it 'has error messages' do
+          questions_ids = [
+            { id: 'invalid' }
+          ]
+          form = described_class.new(survey_id: 'd5de6a8f8f5f1cfe51bc', questions: questions_ids)
+          form.save
+
+          expect(form.errors.messages[:questions]).to include('is invalid')
+        end
+      end
+
+      context 'given an empty questions array' do
+        it 'returns false' do
+          form = described_class.new(survey_id: 'd5de6a8f8f5f1cfe51bc', questions: [])
+
+          expect(form.save).to eq(false)
+        end
+
+        it 'has error messages' do
+          form = described_class.new(survey_id: 'd5de6a8f8f5f1cfe51bc', questions: [])
+          form.save
+
+          expect(form.errors.messages[:questions]).to include("can't be blank")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What happened
Create an API to submit a new survey response

 
## Insight
- This is a temporary API that allows user to send a POST request to create a survey response (it won't save the data)
- Add some basic validations such as checking survey_id, checking list ids of questions
- Create `render_error` method to render the error with JSON API format
 

## Proof Of Work
Check the examples on [Postman](https://nimblehq.postman.co/collections/11835486-63105f38-c20f-493d-b4d8-873a18c8d8c7?version=latest&workspace=9daf6b25-882e-4ad0-8299-95529e2883ff#8de38274-3f9f-4b27-8122-58d7399b4c69)
 