### PR TITLE
As an API user, I can log out

### DIFF
--- a/app/controllers/api/v1/tokens_controller.rb
+++ b/app/controllers/api/v1/tokens_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    class TokensController < Doorkeeper::TokensController
+      # Override Doorkeeper::TokensController#revoke to remove client credentials check
+      # We didn't use any client credentials
+      def revoke
+        # The authorization server responds with HTTP status code 200 if the client
+        # submitted an invalid token or the token has been revoked successfully.
+        if token.blank?
+          render json: {}
+          # The authorization server validates [...] and whether the token
+          # was issued to the client making the revocation request. If this
+          # validation fails, the request is refused and the client is informed
+          # of the error by the authorization server as described below.
+        elsif authorized?
+          revoke_token
+          render json: {}
+        else
+          render json: revocation_error_response, status: :forbidden
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   scope :api do
     scope :v1 do
       use_doorkeeper do
+        controllers tokens: 'api/v1/tokens'
         skip_controllers :applications, :authorizations, :token_info
       end
     end

--- a/spec/controllers/api/v1/tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/tokens_controller_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe API::V1::TokensController, type: :controller do
+  describe 'Filters' do
+    it { is_expected.not_to use_before_action(:doorkeeper_authorize!) }
+  end
+
+  describe 'POST#revoke' do
+    context 'given a valid access token' do
+      it 'returns success status' do
+        Fabricate(:access_token, token: 'access_token')
+
+        post :revoke, params: { token: 'access_token' }
+
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns an empty response' do
+        Fabricate(:access_token, token: 'access_token')
+
+        post :revoke, params: { token: 'access_token' }
+
+        expect(JSON.parse(response.body)).to be_empty
+      end
+    end
+
+    context 'given a valid refresh token' do
+      it 'returns success status' do
+        Fabricate(:access_token, refresh_token: 'refresh_token')
+
+        post :revoke, params: { token: 'refresh_token' }
+
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns an empty response' do
+        Fabricate(:access_token, refresh_token: 'refresh_token')
+
+        post :revoke, params: { token: 'refresh_token' }
+
+        expect(JSON.parse(response.body)).to be_empty
+      end
+    end
+
+    context 'given an invalid token' do
+      it 'returns success status' do
+        post :revoke, params: { token: 'invalid' }
+
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns an empty response' do
+        post :revoke, params: { token: 'invalid' }
+
+        expect(JSON.parse(response.body)).to be_empty
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/tokens_controller_spec.rb
@@ -57,5 +57,19 @@ RSpec.describe API::V1::TokensController, type: :controller do
         expect(JSON.parse(response.body)).to be_empty
       end
     end
+
+    context 'given no token param' do
+      it 'returns success status' do
+        post :revoke
+
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns an empty response' do
+        post :revoke
+
+        expect(JSON.parse(response.body)).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
## What happened
Create an API to revoke the token
 
## Insight
- Because we didn't use any OAuth applications, so we need to override `Doorkeeper::TokensController#revoke` to remove client credentials check
- I just copy from `Doorkeeper::TokensController` and remove the redundant check
- Config doorkeeper to use the custom `tokens_controller`
- The token (refresh_token/access_token) should be sent in the request body
 
## Proof Of Work
[Postman](https://nimblehq.postman.co/collections/11835486-63105f38-c20f-493d-b4d8-873a18c8d8c7?version=latest&workspace=9daf6b25-882e-4ad0-8299-95529e2883ff#bc9cd5d4-a4c8-4692-bfaf-bdc73f080588)
 