### PR TITLE
Change how to get mailgun ENV variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@ ARG ASSET_HOST=http://localhost
 ARG MAILER_DEFAULT_HOST=http://localhost
 ARG MAILER_DEFAULT_PORT=3000
 ARG SECRET_KEY_BASE=secret_key_base
+ARG MAILGUN_SMTP_PORT=mailgun_smtp_port
+ARG MAILGUN_SMTP_SERVER=mailgun_smtp_server
+ARG MAILGUN_SMTP_LOGIN=mailgun_smtp_login
+ARG MAILGUN_SMTP_PASSWORD=mailgun_smtp_password
+ARG APP_DOMAIN=app_domain
 
 # Define all the envs here
 ENV BUILD_ENV=$BUILD_ENV \

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,11 +72,11 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
 
   config.action_mailer.smtp_settings = {
-    port: ENV['MAILGUN_SMTP_PORT'],
-    address: ENV['MAILGUN_SMTP_SERVER'],
-    user_name: ENV['MAILGUN_SMTP_LOGIN'],
-    password: ENV['MAILGUN_SMTP_PASSWORD'],
-    domain: ENV['APP_DOMAIN'],
+    port: ENV.fetch('MAILGUN_SMTP_PORT'),
+    address: ENV.fetch('MAILGUN_SMTP_SERVER'),
+    user_name: ENV.fetch('MAILGUN_SMTP_LOGIN'),
+    password: ENV.fetch('MAILGUN_SMTP_PASSWORD'),
+    domain: ENV.fetch('APP_DOMAIN'),
     authentication: :plain,
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,11 +72,11 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
 
   config.action_mailer.smtp_settings = {
-    port: ENV.fetch('MAILGUN_SMTP_PORT'),
-    address: ENV.fetch('MAILGUN_SMTP_SERVER'),
-    user_name: ENV.fetch('MAILGUN_SMTP_LOGIN'),
-    password: ENV.fetch('MAILGUN_SMTP_PASSWORD'),
-    domain: ENV.fetch('APP_DOMAIN'),
+    port: ENV['MAILGUN_SMTP_PORT'],
+    address: ENV['MAILGUN_SMTP_SERVER'],
+    user_name: ENV['MAILGUN_SMTP_LOGIN'],
+    password: ENV['MAILGUN_SMTP_PASSWORD'],
+    domain: ENV['APP_DOMAIN'],
     authentication: :plain,
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,11 @@ services:
         - RUBY_ENV=production
         - NODE_ENV=production
         - ASSET_HOST
+        - MAILGUN_SMTP_PORT
+        - MAILGUN_SMTP_SERVER
+        - MAILGUN_SMTP_LOGIN
+        - MAILGUN_SMTP_PASSWORD
+        - APP_DOMAIN
     image: ${DOCKER_IMAGE}:${BRANCH_TAG}
     container_name: nimble_survey_web_web
     command: bin/start.sh


### PR DESCRIPTION
## What happened
- Change how to get mailgun ENV variables
- Fix https://github.com/nimblehq/nimble-survey-web/runs/931238484?check_suite_focus=true
 
## Insight
- Add the required variables as ARGs in Dockerfile in order to precompile the assets
- Also add them to docker-compose file

## Proof Of Work
It should not raise errors when building docker file on production
 