### PR TITLE
Add user profile to graphql

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class UserDecorator < SimpleDelegator
+  AVATAR_URL_FORMAT = 'https://api.adorable.io/avatar/%{email}'
+
+  def avatar_url
+    format(AVATAR_URL_FORMAT, email: email)
+  end
+end

--- a/app/graphql/resolvers/user_resolver.rb
+++ b/app/graphql/resolvers/user_resolver.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class UserResolver < BaseResolver
+    description 'User profile'
+
+    type Types::UserType, null: false
+
+    def resolve
+      context[:current_user]
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -3,5 +3,6 @@
 module Types
   class QueryType < Types::Base::Object
     field :surveys, resolver: Resolvers::SurveyResolver
+    field :profile, resolver: Resolvers::UserResolver
   end
 end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Types
+  class UserType < Types::Base::Object
+    field :id, ID, null: false
+    field :email, String, null: false
+    field :avatar_url, String, null: false
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,12 @@ class User < ApplicationRecord
            foreign_key: :resource_owner_id,
            inverse_of: :resource_owner,
            dependent: :delete_all
+
+  delegate :avatar_url, to: :user_decorator
+
+  private
+
+  def user_decorator
+    @user_decorator ||= UserDecorator.new(self)
+  end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
 class UserSerializer < ApplicationSerializer
-  AVATAR_URL_FORMAT = 'https://api.adorable.io/avatar/%{email}'
-
-  attribute :email
-
-  attribute :avatar_url do |user|
-    format(AVATAR_URL_FORMAT, email: user.email)
-  end
+  attributes :email, :avatar_url
 end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -2,14 +2,14 @@
 
 require 'rails_helper'
 
-RSpec.describe UserSerializer do
+RSpec.describe UserDecorator do
   describe '#avatar_url' do
     it 'returns the avatar url based on the email' do
       user = Fabricate(:user, email: 'hoang.mirs@gmail.com')
-      serializer = described_class.new(user)
+      decorator = described_class.new(user)
 
       expected_url = 'https://api.adorable.io/avatar/hoang.mirs@gmail.com'
-      expect(serializer.serializable_hash[:data][:attributes][:avatar_url]).to eq(expected_url)
+      expect(decorator.avatar_url).to eq(expected_url)
     end
   end
 end

--- a/spec/graphql/resolvers/user_resolver_spec.rb
+++ b/spec/graphql/resolvers/user_resolver_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::UserResolver do
+  it 'returns user profile' do
+    query_string = <<-GRAPHQL
+      query UserProfile{
+        profile {
+          id
+          email
+          avatar_url
+        }
+      }
+    GRAPHQL
+
+    user = Fabricate(:user, email: 'hoang.mirs@gmail.com')
+
+    result = NimbleSurveyWebSchema.execute(query_string, variables: {}, context: { current_user: user })
+
+    profile = result['data']['profile']
+
+    expect(profile['id']).to eq(user.id.to_s)
+    expect(profile['email']).to eq(user.email)
+    expect(profile['avatar_url']).to eq(user.avatar_url)
+  end
+end

--- a/spec/graphql/resolvers/user_resolver_spec.rb
+++ b/spec/graphql/resolvers/user_resolver_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Resolvers::UserResolver do
         profile {
           id
           email
-          avatar_url
+          avatarUrl
         }
       }
     GRAPHQL
@@ -22,6 +22,6 @@ RSpec.describe Resolvers::UserResolver do
 
     expect(profile['id']).to eq(user.id.to_s)
     expect(profile['email']).to eq(user.email)
-    expect(profile['avatar_url']).to eq(user.avatar_url)
+    expect(profile['avatarUrl']).to eq(user.avatar_url)
   end
 end


### PR DESCRIPTION
## What happened
Add user profile to graphql endpoint
 
## Insight
- Create UserDecorator to generate the avatar URL
- Add that decorator to model
- Create new resolver for User and add `profile` query

## Proof Of Work
![GraphiQL](https://user-images.githubusercontent.com/7344405/91039887-8f4d0280-e637-11ea-9ac7-fb6e566a47d8.png)

 