### PR TITLE
Revert removing sprockets to support the external gems

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,11 +1,6 @@
 require_relative 'boot'
 
-require 'active_record/railtie'
-require 'active_storage/engine'
-require 'action_controller/railtie'
-require 'action_view/railtie'
-require 'action_mailer/railtie'
-require 'action_cable/engine'
+require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,6 +54,14 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  # Debug mode disables concatenation and preprocessing of assets.
+  # This option may cause significant delays in view rendering with a large
+  # number of complex assets.
+  config.assets.debug = true
+
+  # Suppress logger output for asset requests.
+  config.assets.quiet = true
+
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,6 +22,12 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
+  # Compress CSS using a preprocessor.
+  # config.assets.css_compressor = :sass
+
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -63,4 +63,7 @@ Rails.application.configure do
 
   # Disable all animation during tests
   config.middleware.use Rack::NoAnimations
+
+  # Do not fallback to assets pipeline if a precompiled asset is missing.
+  config.assets.compile = false
 end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,0 +1,14 @@
+# Be sure to restart your server when you modify this file.
+
+# Version of your assets, change this if you want to expire all your assets.
+Rails.application.config.assets.version = '1.0'
+
+# Add additional assets to the asset load path.
+# Rails.application.config.assets.paths << Emoji.images_path
+# Add Yarn node_modules folder to the asset load path.
+# Rails.application.config.assets.paths << Rails.root.join('node_modules')
+
+# Precompile additional assets.
+# application.js, application.css, and all non-JS/CSS in the app/assets
+# folder are already added.
+# Rails.application.config.assets.precompile += %w( admin.js admin.css )


### PR DESCRIPTION
## What happened
- The CSS of Doorkeeper can not be loaded
- We still need the sprockets for compiling the external gems' assets so we need to revert the deletion
 
## Insight
- Revert the changes when [removing sprockets](https://github.com/nimblehq/nimble-survey-web/pull/20/files)
- In main app, I don't need sprockets to load assets, so I set nothing in `assets/config/manifest.js` and don't add `node_modules` to the assets load path

## Proof Of Work
- Tests should be passed
- The assets can be compiled successfully
![Add_workflow_dispatch_trigger_for_deploy_workflow_·_nimblehq_nimble-survey-web_2cf88c6](https://user-images.githubusercontent.com/7344405/92721133-ca696880-f38f-11ea-8768-ffddd72c6ab6.png)

 