### PR TITLE
Add workflow_dispatch trigger for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - development
+  workflow_dispatch:
 
 env:
   DOCKER_HUB_USERNAME: ${{ github.repository_owner }}


### PR DESCRIPTION
## What happened
Sometimes we want to deploy a branch to staging to test the changes on the server, so we need to add another trigger to run the workflow manually

 
## Insight
- Add `workflow_dispatch` trigger for deploy workflow
- You can check more details of the `workflow_dispatch` event on [this blog](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) or [docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch)
- Currently, if the $BRANCH_TAG is `master`, it will be deployed to production server, otherwise, it will go on staging server

## Proof Of Work
As it needs to be merged to the default branch, I added it on another repository:
![Actions_·_hoangmirs_test-repo](https://user-images.githubusercontent.com/7344405/92852204-a1d98100-f418-11ea-95ce-a30454675cca.png)

 