### PR TITLE
Enable force_ssl on production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
## What happened
Force the application to use SSL/TLS

 
## Insight
- Just enable `config.force_ssl = true` in `config/environments/production.rb`
- https://help.heroku.com/J2R1S4T8/can-heroku-force-an-application-to-use-ssl-tls

## Proof Of Work
Tested on the staging
 