### PR TITLE
Modify reek config to exclude spec support folder

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -48,4 +48,4 @@ directories:
 
 # Directories below will not be scanned at all
 exclude_paths:
-  - spec/support/
+  - spec/support

--- a/spec/support/disable_animation.rb
+++ b/spec/support/disable_animation.rb
@@ -29,35 +29,31 @@ module Rack
     end
 
     # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Naming/HeredocDelimiterNaming
-    # rubocop:disable Layout/HeredocIndentation
     def inject(fragment)
-      disable_animations = <<-EOF
-<script type="text/javascript">(typeof jQuery !== 'undefined') && (jQuery.fx.off = true);</script>
-<style>
-  * {
-     -o-transition: none !important;
-     -moz-transition: none !important;
-     -ms-transition: none !important;
-     -webkit-transition: none !important;
-     transition: none !important;
-     -o-transform: none !important;
-     -moz-transform: none !important;
-     -ms-transform: none !important;
-     -webkit-transform: none !important;
-     transform: none !important;
-     -webkit-animation: none !important;
-     -moz-animation: none !important;
-     -o-animation: none !important;
-     -ms-animation: none !important;
-     animation: none !important;
-  }
-</style>
-      EOF
+      disable_animations = <<~SCRIPT
+        <script type="text/javascript">(typeof jQuery !== 'undefined') && (jQuery.fx.off = true);</script>
+        <style>
+          * {
+             -o-transition: none !important;
+             -moz-transition: none !important;
+             -ms-transition: none !important;
+             -webkit-transition: none !important;
+             transition: none !important;
+             -o-transform: none !important;
+             -moz-transform: none !important;
+             -ms-transform: none !important;
+             -webkit-transform: none !important;
+             transform: none !important;
+             -webkit-animation: none !important;
+             -moz-animation: none !important;
+             -o-animation: none !important;
+             -ms-animation: none !important;
+             animation: none !important;
+          }
+        </style>
+      SCRIPT
       fragment.gsub(%r{</head>}, "#{disable_animations}</head>")
     end
     # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Naming/HeredocDelimiterNaming
-    # rubocop:enable Layout/HeredocIndentation
   end
 end


### PR DESCRIPTION
## Why
- `exclude_paths` is not supported when running in Danger, the ignored files have still been run.
- Although Reek supported `--force_exclusion` param https://github.com/troessner/reek/pull/1200, we can not use it with `Reek::Examiner`. That why we need to handle it ourself

## Insights
- I created a PR to the [Danger Reek](https://github.com/blooper05/danger-reek/pull/39). 
- Let's wait for them to merge. If it's still there for a long time, I will fork it to Nimble and maintain it by ourself
 

## Proof Of Work
Show us the implementation: screenshots, gif, etc.
 