### PR TITLE
Support dynamic docker registry

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
-DOCKER_IMAGE=nimblehq/nimble_survey_web
-BRANCH_TAG=latest
+DOCKER_REGISTRY=docker.io
+DOCKER_IMAGE=nimblehq/nimble-survey-web
+BRANCH_TAG=master
 PORT=80
 CI=false
 TEST_RETRY=true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,8 +8,9 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_HUB_USERNAME: ${{ github.repository_owner }}
-  DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+  DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+  DOCKER_USERNAME: ${{ github.repository_owner }}
+  DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
   HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
   DOCKER_IMAGE: ${{ github.repository }}
 
@@ -31,7 +32,7 @@ jobs:
           fi
 
       - name: Docker login
-        run: echo "$DOCKER_HUB_TOKEN" | docker login --username=$DOCKER_HUB_USERNAME --password-stdin
+        run: echo "$DOCKER_TOKEN" | docker login $DOCKER_REGISTRY --username=$DOCKER_USERNAME --password-stdin
 
       - name: Docker build
         run: |
@@ -44,5 +45,5 @@ jobs:
 
       - name: Heroku release
         run: |
-          heroku container:push --arg DOCKER_IMAGE=$DOCKER_IMAGE,BRANCH_TAG=$BRANCH_TAG --recursive
+          heroku container:push --arg DOCKER_REGISTRY=$DOCKER_REGISTRY,DOCKER_IMAGE=$DOCKER_IMAGE,BRANCH_TAG=$BRANCH_TAG --recursive
           heroku container:release web worker

--- a/.github/workflows/docker_build_test.yml
+++ b/.github/workflows/docker_build_test.yml
@@ -11,6 +11,7 @@ jobs:
     name: Docker production test
     runs-on: ubuntu-latest
     env:
+      DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
       DOCKER_IMAGE: ${{ github.repository }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,9 @@ name: Test
 on: push
 
 env:
-  DOCKER_HUB_USERNAME: ${{ github.repository_owner }}
-  DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+  DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+  DOCKER_USERNAME: ${{ github.repository_owner }}
+  DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
   COMPOSE_FILE: docker-compose.test.yml
   DOCKER_IMAGE: ${{ github.repository }}
 
@@ -18,11 +19,11 @@ jobs:
       - uses: nimblehq/branch-tag-action@v1
 
       - name: Docker login
-        run: echo "$DOCKER_HUB_TOKEN" | docker login --username=$DOCKER_HUB_USERNAME --password-stdin
+        run: echo "$DOCKER_TOKEN" | docker login $DOCKER_REGISTRY --username=$DOCKER_USERNAME --password-stdin
 
       - name: Docker pull
         if: env.BRANCH_TAG != 'master' && env.BRANCH_TAG != 'development'
-        run: docker-compose pull test
+        run: docker-compose pull test || true
 
       - name: Docker build
         run: |
@@ -40,7 +41,7 @@ jobs:
       - uses: nimblehq/branch-tag-action@v1
 
       - name: Docker login
-        run: echo "$DOCKER_HUB_TOKEN" | docker login --username=$DOCKER_HUB_USERNAME --password-stdin
+        run: echo "$DOCKER_TOKEN" | docker login $DOCKER_REGISTRY --username=$DOCKER_USERNAME --password-stdin
 
       - name: Docker pull
         run: docker-compose pull
@@ -61,7 +62,7 @@ jobs:
       - uses: nimblehq/branch-tag-action@v1
 
       - name: Docker login
-        run: echo "$DOCKER_HUB_TOKEN" | docker login --username=$DOCKER_HUB_USERNAME --password-stdin
+        run: echo "$DOCKER_TOKEN" | docker login $DOCKER_REGISTRY --username=$DOCKER_USERNAME --password-stdin
 
       - name: Docker pull
         run: docker-compose pull

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,5 +1,6 @@
+ARG DOCKER_REGISTRY=docker.io
 ARG DOCKER_IMAGE=nimblehq/nimble-survey-web
-ARG BRANCH_TAG=latest
-FROM ${DOCKER_IMAGE}:${BRANCH_TAG}
+ARG BRANCH_TAG=master
+FROM ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${BRANCH_TAG}
 
 CMD ["./bin/start.sh"]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,5 +1,6 @@
+ARG DOCKER_REGISTRY=docker.io
 ARG DOCKER_IMAGE=nimblehq/nimble-survey-web
-ARG BRANCH_TAG=latest
-FROM ${DOCKER_IMAGE}:${BRANCH_TAG}
+ARG BRANCH_TAG=master
+FROM ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${BRANCH_TAG}
 
 CMD ["./bin/sidekiq.sh"]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -19,12 +19,12 @@ services:
     build:
       context: .
       cache_from:
-        - ${DOCKER_IMAGE}:${BRANCH_TAG}
+        - ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${BRANCH_TAG}
       args:
         - BUILD_ENV=test
         - RUBY_ENV=test
         - NODE_ENV=test
-    image: ${DOCKER_IMAGE}:${BRANCH_TAG}
+    image: ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${BRANCH_TAG}
     container_name: nimble_survey_web_test
     command: bin/test.sh
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     build:
       context: .
       cache_from:
-        - ${DOCKER_IMAGE}:${BRANCH_TAG}
+        - ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${BRANCH_TAG}
       args:
         - BUILD_ENV=production
         - RUBY_ENV=production
@@ -32,7 +32,7 @@ services:
         - APP_DOMAIN
         - BASIC_AUTHENTICATION_USERNAME
         - BASIC_AUTHENTICATION_PASSWORD
-    image: ${DOCKER_IMAGE}:${BRANCH_TAG}
+    image: ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${BRANCH_TAG}
     container_name: nimble_survey_web_web
     command: bin/start.sh
     ports:


### PR DESCRIPTION
## What happened
- Github introduced the [Github Container Registry](https://github.blog/2020-09-01-introducing-github-container-registry/) at the beginning of the month
- Try using it
 
## Insight
- Modify the Docker image name so that it can be used for both `docker.io` and `ghcr.io`
- Modify Github actions workflows to be able to log in with different registries
- To avoid set `DOCKER_REGISTRY` manually in the workflows, use secrets instead
 

## Proof Of Work
- Tested and worked for both registries(docker.io and ghcr.io)
- Try deploying on staging and it works perfectly