### PR TITLE
Update branch_tag action version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: nimblehq/branch-tag-action@v1
+      - uses: nimblehq/branch-tag-action@v1.1
 
       - name: Set HEROKU_APP
         run: |

--- a/.github/workflows/docker_build_test.yml
+++ b/.github/workflows/docker_build_test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: nimblehq/branch-tag-action@v1
+      - uses: nimblehq/branch-tag-action@v1.1
 
       - name: Docker build production
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: nimblehq/branch-tag-action@v1
+      - uses: nimblehq/branch-tag-action@v1.1
 
       - name: Docker login
         run: echo "$DOCKER_HUB_TOKEN" | docker login --username=$DOCKER_HUB_USERNAME --password-stdin
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: nimblehq/branch-tag-action@v1
+      - uses: nimblehq/branch-tag-action@v1.1
 
       - name: Docker login
         run: echo "$DOCKER_HUB_TOKEN" | docker login --username=$DOCKER_HUB_USERNAME --password-stdin
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: nimblehq/branch-tag-action@v1
+      - uses: nimblehq/branch-tag-action@v1.1
 
       - name: Docker login
         run: echo "$DOCKER_HUB_TOKEN" | docker login --username=$DOCKER_HUB_USERNAME --password-stdin


### PR DESCRIPTION
## What happened
As we have a [new release](https://github.com/nimblehq/branch-tag-action/releases/tag/v1.1) for Branch tag Gtihub action, then I wanna use the newer version

## Insight
N/A
 

## Proof Of Work
N/A
 