### PR TITLE
Add postfix to docker test image

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -19,12 +19,12 @@ services:
     build:
       context: .
       cache_from:
-        - ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${BRANCH_TAG}
+        - ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${BRANCH_TAG}-test
       args:
         - BUILD_ENV=test
         - RUBY_ENV=test
         - NODE_ENV=test
-    image: ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${BRANCH_TAG}
+    image: ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${BRANCH_TAG}-test
     container_name: nimble_survey_web_test
     command: bin/test.sh
     stdin_open: true


### PR DESCRIPTION
## What happened
It should be better if we have separated names for test and main images.
Therefore, I added `test` postfix to the name of test images

## Insight
N/A
 

## Proof Of Work
N/A