### PR TITLE
Update github actions workflows

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 DOCKER_REGISTRY=docker.io
 DOCKER_IMAGE=nimblehq/nimble-survey-web
-BRANCH_TAG=master
+BRANCH_TAG=latest
 PORT=80
 CI=false
 TEST_RETRY=true

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -9,62 +9,67 @@ jobs:
     name: Run Danger
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 100
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ github.token }}
 
-    - uses: actions/setup-ruby@v1
-      with:
-        ruby-version: '2.7.1'
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 100
 
-    - uses: actions/setup-node@v2-beta
-      with:
-        node-version: '12'
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.7.1'
 
-    - name: Bundle cache
-      uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
 
-    - name: Bundle install
-      run: |
-        gem install bundler
-        bundle config path vendor/bundle
-        bundle config set with 'development'
-        bundle install --jobs 4 --retry 3
+      - name: Bundle cache
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
 
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Bundle install
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
+          bundle config set with 'development'
+          bundle install --jobs 4 --retry 3
 
-    - name: Yarn cache
-      uses: actions/cache@v2
-      id: yarn-cache
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
 
-    - name: node_modules cache
-      id: node-modules-cache
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-nodemodules-
+      - name: Yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-    - name: Yarn install
-      run: yarn
-      if: |
-        steps.yarn-cache.outputs.cache-hit != 'true' ||
-        steps.node-modules-cache.outputs.cache-hit != 'true'
+      - name: node_modules cache
+        id: node-modules-cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-nodemodules-
 
-    - name: Run Danger
-      run: bundle exec danger
-      env:
-        DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+      - name: Yarn install
+        run: yarn
+        if: |
+          steps.yarn-cache.outputs.cache-hit != 'true' ||
+          steps.node-modules-cache.outputs.cache-hit != 'true'
+
+      - name: Run Danger
+        run: bundle exec danger
+        env:
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,14 @@
 name: Deploy
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - Test
     branches:
       - master
       - development
+    types:
+      - completed
   workflow_dispatch:
 
 env:
@@ -17,6 +21,7 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.5.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,13 +18,18 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ github.token }}
+
       - uses: actions/checkout@v2
 
       - uses: nimblehq/branch-tag-action@v1.1
 
       - name: Set HEROKU_APP
         run: |
-          if [[ $BRANCH_TAG = "master" ]]
+          if [[ $BRANCH_TAG = "latest" ]]
           then
             echo "::set-env name=HEROKU_APP::nimble-survey-web"
           else

--- a/.github/workflows/docker_build_test.yml
+++ b/.github/workflows/docker_build_test.yml
@@ -14,6 +14,11 @@ jobs:
       DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
       DOCKER_IMAGE: ${{ github.repository }}
     steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ github.token }}
+
       - uses: actions/checkout@v2
 
       - uses: nimblehq/branch-tag-action@v1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,11 @@ jobs:
     name: Build docker image
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ github.token }}
+
       - uses: actions/checkout@v2
 
       - uses: nimblehq/branch-tag-action@v1.1
@@ -22,7 +27,7 @@ jobs:
         run: echo "$DOCKER_TOKEN" | docker login $DOCKER_REGISTRY --username=$DOCKER_USERNAME --password-stdin
 
       - name: Docker pull
-        if: env.BRANCH_TAG != 'master' && env.BRANCH_TAG != 'development'
+        if: env.BRANCH_TAG != 'latest' && env.BRANCH_TAG != 'development'
         run: docker-compose pull test || true
 
       - name: Docker build

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,6 +1,6 @@
 ARG DOCKER_REGISTRY=docker.io
 ARG DOCKER_IMAGE=nimblehq/nimble-survey-web
-ARG BRANCH_TAG=master
+ARG BRANCH_TAG=latest
 FROM ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${BRANCH_TAG}
 
 CMD ["./bin/start.sh"]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,6 +1,6 @@
 ARG DOCKER_REGISTRY=docker.io
 ARG DOCKER_IMAGE=nimblehq/nimble-survey-web
-ARG BRANCH_TAG=master
+ARG BRANCH_TAG=latest
 FROM ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${BRANCH_TAG}
 
 CMD ["./bin/sidekiq.sh"]


### PR DESCRIPTION
## What happened
- Add auto cancel previous workflows
- Rename master tag to latest
- Only run deploy workflows after the test workflows succeeded on default branches
 
## Insight
- Use [this action](https://github.com/styfle/cancel-workflow-action) to cancel the previous runs, no need to run the redundant runs when we push new source code
- Rename `master` tag to `latest` tag since we use branch-tag@v1.1
- Reindent danger workflow file
- Use `workflow_run` event in `deploy` workflow. Then now, it will be run when the `Test` workflow completed on `master` and `development` branches ([link](https://github.community/t/workflow-run-completed-event-triggered-by-failed-workflow/128001/2))

## Proof Of Work
All workflows should run properly