### PR TITLE
Fix cannot deploy on master branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.5.0
@@ -29,8 +29,12 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2.3.2
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - uses: nimblehq/branch-tag-action@v1.1
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - name: Set HEROKU_APP
         run: |


### PR DESCRIPTION
## What happened
- Currently, we cannot run the deployment on the master branch. The issue is this workflow can be triggered by other workflows from any branches, but `workflow_run`event is only run on the default branch. That why the `GITHUB_REF` always returns `development`
- This fix will allow the workflow can be called with the correct branch
 
## Insight
- Github didn't mention that issue on the docs, I found it on [this link](https://github.community/t/workflow-runs-not-starting-after-previous-workflow-completes/128345/8)
> And this workflow will only run on the master or default branch, regardless of whether it is triggered by a workflow run on other branches or not.

- Specify the `ref` param for `actions/checkout` and `nimblehq/branch-tag-action` so that they can get the correct current branch
- Add `github.event_name != 'workflow_run'` condition to allow this workflow can be run with other events, not only `workflow_run` event. If we use only `${{ github.event.workflow_run.conclusion == 'success' }}`, it would be run if the previous workflow succeeded only.

## Proof Of Work
Tested on my private repository
 