### PR TITLE
Update actions/checkout to latest version

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.2
         with:
           fetch-depth: 100
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.2
 
       - uses: nimblehq/branch-tag-action@v1.1
 

--- a/.github/workflows/docker_build_test.yml
+++ b/.github/workflows/docker_build_test.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.2
 
       - uses: nimblehq/branch-tag-action@v1.1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.2
 
       - uses: nimblehq/branch-tag-action@v1.1
 
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.2
 
       - uses: nimblehq/branch-tag-action@v1.1
 
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.2
 
       - uses: nimblehq/branch-tag-action@v1.1
 


### PR DESCRIPTION
## What happened
Just update the `actions/checkout` to use the latest version
 
## Insight
https://github.com/marketplace/actions/checkout?version=v2.3.2 

## Proof Of Work
N/A 