### PR TITLE
Fix: Wrong error format when requesting GraphQL with invalid token

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -31,12 +31,6 @@ class GraphqlController < ActionController::API
     end
   end
 
-  def current_user
-    return User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token && !doorkeeper_token.expired?
-
-    raise Doorkeeper::Errors::DoorkeeperError, 'Invalid access token'
-  end
-
   # :reek:FeatureEnvy
   # rubocop:disable Metrics/MethodLength
   def doorkeeper_unauthorized_render_options(error: nil)

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -32,11 +32,9 @@ class GraphqlController < ActionController::API
   end
 
   def current_user
-    if doorkeeper_token && !doorkeeper_token.expired?
-      return User.find(doorkeeper_token.resource_owner_id)
-    end
+    return User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token && !doorkeeper_token.expired?
 
-    raise Doorkeeper::Errors::DoorkeeperError, "Invalid access token"
+    raise Doorkeeper::Errors::DoorkeeperError, 'Invalid access token'
   end
 
   # :reek:FeatureEnvy
@@ -53,7 +51,7 @@ class GraphqlController < ActionController::API
               state: error.state
             }
           }
-        ],
+        ]
       }
     }
   end

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -38,6 +38,7 @@ class GraphqlController < ActionController::API
   end
 
   # :reek:FeatureEnvy
+  # rubocop:disable Metrics/MethodLength
   def doorkeeper_unauthorized_render_options(error: nil)
     return unless error
 
@@ -55,4 +56,5 @@ class GraphqlController < ActionController::API
       }
     }
   end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/app/graphql/nimble_survey_web_schema.rb
+++ b/app/graphql/nimble_survey_web_schema.rb
@@ -3,11 +3,4 @@
 class NimbleSurveyWebSchema < GraphQL::Schema
   mutation(Types::MutationType)
   query(Types::QueryType)
-
-  # Opt in to the new runtime (default in future graphql-ruby versions)
-  use GraphQL::Execution::Interpreter
-  use GraphQL::Analysis::AST
-
-  # Add built-in connections for pagination
-  use GraphQL::Pagination::Connections
 end

--- a/spec/controllers/graphql_controller_spec.rb
+++ b/spec/controllers/graphql_controller_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GraphqlController, type: :controller do
+  describe 'POST#create' do
+    context 'given an authenticated request', auth: :user_token do
+      it 'returns success status' do
+        post :create, params: { query: sample_query, variables: {} }
+
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'given an unauthenticated request' do
+      it 'returns unauthorized status' do
+        post :create, params: { query: sample_query, variables: {} }
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns the correct error response format' do
+        post :create, params: { query: sample_query, variables: {} }
+
+        response_body = JSON.parse(response.body)
+        expect(response_body).to match_json_schema('graphql/invalid_token')
+      end
+    end
+  end
+
+  private
+
+  def sample_query
+    <<~GRAPHQL
+      query{
+        profile{
+          avatarUrl
+          email
+          id
+        }
+      }
+    GRAPHQL
+  end
+end

--- a/spec/controllers/graphql_controller_spec.rb
+++ b/spec/controllers/graphql_controller_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe GraphqlController, type: :controller do
 
   def sample_query
     <<~GRAPHQL
-      query{
-        profile{
+      query {
+        profile {
           avatarUrl
           email
           id

--- a/spec/controllers/graphql_controller_spec.rb
+++ b/spec/controllers/graphql_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe GraphqlController, type: :controller do
         post :create, params: { query: sample_query, variables: {} }
 
         response_body = JSON.parse(response.body)
-        expect(response_body).to match_json_schema('graphql/invalid_token')
+        expect(response_body).to match_json_schema('graphql/create/invalid_token')
       end
     end
   end

--- a/spec/support/api/schemas/graphql/create/invalid_token.json
+++ b/spec/support/api/schemas/graphql/create/invalid_token.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "extensions": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "state": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "code",
+              "state"
+            ]
+          }
+        },
+        "required": [
+          "message",
+          "extensions"
+        ]
+      }
+    }
+  },
+  "required": [
+    "errors"
+  ]
+}


### PR DESCRIPTION
Resolve https://github.com/nimblehq/nimble-survey-web/issues/51

## What happened
Fix the incorrect error message when an access token is expired
 
## Insight
- Override `doorkeeper_unauthorized_render_options` in `graphql_controller` with the correct message
- Remove redundant code when upgrading GraphQL lib
 

## Proof Of Work
Before:
![Altair](https://user-images.githubusercontent.com/7344405/121122631-01e84100-c84c-11eb-95b2-2b0f6b225343.png)


After:
![Altair](https://user-images.githubusercontent.com/7344405/121122578-e846f980-c84b-11eb-93b0-7ac03fc08596.png)

 