### PR TITLE
Validate email format on Forgot password API

### DIFF
--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -6,10 +6,14 @@ module API
       include API::V1::OauthApplicationVerifiable
 
       def create
-        super do
-          render json: {
-            meta: { message: t('devise.passwords.send_paranoid_instructions') }
-          }
+        super do |user|
+          if user.valid_attribute?(:email)
+            render json: {
+              meta: { message: t('devise.passwords.send_paranoid_instructions') }
+            }
+          else
+            render_error(detail: user.errors.full_messages_for(:email).first)
+          end
 
           # Skip other stuff from devise
           return

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,8 +14,8 @@ class User < ApplicationRecord
   delegate :avatar_url, to: :user_decorator
 
   def valid_attribute?(attribute_name)
-    self.valid?
-    self.errors[attribute_name].blank?
+    valid?
+    errors[attribute_name].blank?
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,11 @@ class User < ApplicationRecord
 
   delegate :avatar_url, to: :user_decorator
 
+  def valid_attribute?(attribute_name)
+    self.valid?
+    self.errors[attribute_name].blank?
+  end
+
   private
 
   def user_decorator

--- a/spec/controllers/api/v1/passwords_controller_spec.rb
+++ b/spec/controllers/api/v1/passwords_controller_spec.rb
@@ -11,38 +11,19 @@ RSpec.describe API::V1::PasswordsController, type: :controller do
   describe 'POST#create', devise_mapping: true do
     context 'given a valid oauth application' do
       context 'given valid params' do
-        it 'returns success status' do
-          Fabricate(:user, email: 'dev@nimblehq.co')
-
-          post :create, params: { email: 'dev@nimblehq.co' }.merge(oauth_application_params)
-
-          expect(response).to have_http_status(:success)
-        end
-
-        it 'has a message' do
-          Fabricate(:user, email: 'dev@nimblehq.co')
-
-          post :create, params: { email: 'dev@nimblehq.co' }.merge(oauth_application_params)
-
-          expected_response = {
-            meta: {
-              message: I18n.t('devise.passwords.send_paranoid_instructions')
-            }
-          }
-          expect(JSON.parse(response.body, symbolize_names: true)).to eq(expected_response)
-        end
-      end
-
-      context 'given invalid params' do
-        context 'given no email' do
+        context 'given an existing email' do
           it 'returns success status' do
-            post :create, params: oauth_application_params
+            Fabricate(:user, email: 'dev@nimblehq.co')
+
+            post :create, params: { user: { email: 'dev@nimblehq.co' } }.merge(oauth_application_params)
 
             expect(response).to have_http_status(:success)
           end
 
           it 'has a message' do
-            post :create, params: oauth_application_params
+            Fabricate(:user, email: 'dev@nimblehq.co')
+
+            post :create, params: { user: { email: 'dev@nimblehq.co' } }.merge(oauth_application_params)
 
             expected_response = {
               meta: {
@@ -55,13 +36,13 @@ RSpec.describe API::V1::PasswordsController, type: :controller do
 
         context 'given a non-existing email' do
           it 'returns success status' do
-            post :create, params: { email: 'dev@nimblehq.co' }.merge(oauth_application_params)
+            post :create, params: { user: { email: 'dev@nimblehq.co' } }.merge(oauth_application_params)
 
             expect(response).to have_http_status(:success)
           end
 
           it 'has a message' do
-            post :create, params: { email: 'dev@nimblehq.co' }.merge(oauth_application_params)
+            post :create, params: { user: { email: 'dev@nimblehq.co' } }.merge(oauth_application_params)
 
             expected_response = {
               meta: {
@@ -72,17 +53,61 @@ RSpec.describe API::V1::PasswordsController, type: :controller do
           end
         end
       end
+
+      context 'given invalid params' do
+        context 'given no email' do
+          it 'returns unprocessable_entity status' do
+            post :create, params: oauth_application_params
+
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+
+          it 'has the correct error message' do
+            post :create, params: oauth_application_params
+
+            expected_response = {
+              errors: [
+                {
+                  detail: "Email can't be blank"
+                }
+              ]
+            }
+            expect(JSON.parse(response.body, symbolize_names: true)).to eq(expected_response)
+          end
+        end
+
+        context 'given an invalid email' do
+          it 'returns unprocessable_entity status' do
+            post :create, params: { user: { email: 'invalid email' } }.merge(oauth_application_params)
+
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+
+          it 'has the correct error message' do
+            post :create, params: { user: { email: 'invalid email' } }.merge(oauth_application_params)
+
+            expected_response = {
+              errors: [
+                {
+                  detail: 'Email is invalid'
+                }
+              ]
+            }
+            expect(JSON.parse(response.body, symbolize_names: true)).to eq(expected_response)
+          end
+        end
+      end
     end
 
     context 'given an invalid oauth application' do
       it 'returns forbidden status' do
-        post :create, params: { email: 'dev@nimblehq.co' }
+        post :create, params: { user: { email: 'dev@nimblehq.co' } }
 
         expect(response).to have_http_status(:forbidden)
       end
 
       it 'returns an error message' do
-        post :create, params: { email: 'dev@nimblehq.co' }
+        post :create, params: { user: { email: 'dev@nimblehq.co' } }
 
         expected_response = {
           errors: [


### PR DESCRIPTION
Resolve #48 

## What happened
Validate email format on Forgot password API

 
## Insight
- Add the logic to validate the email field in `passwords_controller` and render the correct error message.
- Fix specs
 

## Proof Of Work
Valid email:
![Postman](https://user-images.githubusercontent.com/7344405/121160226-180af700-c876-11eb-8261-4a3f9be6a637.png)


Blank email:
![Postman](https://user-images.githubusercontent.com/7344405/121160125-01fd3680-c876-11eb-9459-851e30095c0a.png)


Invalid email:
![Postman](https://user-images.githubusercontent.com/7344405/121160016-ec880c80-c875-11eb-8c7f-2a60fe4d5f2b.png)
