### PR TITLE
Remove all the related OAuth2 resources when deleting an OAuth2 application

### DIFF
--- a/db/migrate/20210610040352_create_oauth_access_grants.rb
+++ b/db/migrate/20210610040352_create_oauth_access_grants.rb
@@ -1,0 +1,19 @@
+class CreateOauthAccessGrants < ActiveRecord::Migration[6.0]
+  def change
+    create_table :oauth_access_grants do |t|
+      t.references :resource_owner,  null: false
+      t.references :application,     null: false
+      t.text     :token,             null: false
+      t.integer  :expires_in,        null: false
+      t.text     :redirect_uri,      null: false
+      t.datetime :created_at,        null: false
+      t.datetime :revoked_at
+      t.string   :scopes,            null: false, default: ''
+    end
+
+    add_index :oauth_access_grants, :token, unique: true
+
+    add_foreign_key :oauth_access_grants, :oauth_applications, column: :application_id
+    add_foreign_key :oauth_access_grants, :users, column: :resource_owner_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_10_083238) do
+ActiveRecord::Schema.define(version: 2021_06_10_040352) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "oauth_access_grants", force: :cascade do |t|
+    t.bigint "resource_owner_id", null: false
+    t.bigint "application_id", null: false
+    t.text "token", null: false
+    t.integer "expires_in", null: false
+    t.text "redirect_uri", null: false
+    t.datetime "created_at", null: false
+    t.datetime "revoked_at"
+    t.string "scopes", default: "", null: false
+    t.index ["application_id"], name: "index_oauth_access_grants_on_application_id"
+    t.index ["resource_owner_id"], name: "index_oauth_access_grants_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
+  end
 
   create_table "oauth_access_tokens", force: :cascade do |t|
     t.bigint "resource_owner_id"
@@ -54,6 +68,8 @@ ActiveRecord::Schema.define(version: 2020_08_10_083238) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
 end


### PR DESCRIPTION
Resolve #47 

## What happened
Fix to remove all the related OAuth2 resources when deleting an OAuth2 application
 
## Insight
Before, we couldn't remove an application record as we didn't use `oauth_access_grants`, and the destruction raised an error. So in this PR, just add that `oauth_access_grants` to make it work

## Proof Of Work
Before:
![foreman_start_-f_Procfile_dev](https://user-images.githubusercontent.com/7344405/121465558-37259800-c9e0-11eb-90f3-1ded57a1493f.png)

After:
![foreman_start_-f_Procfile_dev](https://user-images.githubusercontent.com/7344405/121465291-ba92b980-c9df-11eb-8e14-afd9186f8b82.png)
