### PR TITLE
Replace unmaintained fast_jsonapi with new jsonapi-serializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'fabrication' # Fabrication generates objects in Ruby. Fabricators are schem
 gem 'sidekiq' # background processing for Ruby
 gem 'bootsnap', require: false # Reduces boot times through caching; required in config/boot.rb
 gem 'i18n-js', '3.5.1' # A library to provide the I18n translations on the Javascript
-gem 'fast_jsonapi' # A lightning fast JSON:API serializer for Ruby Objects
+gem 'jsonapi-serializer' # A fast JSON:API serializer for Ruby
 gem 'rack-cors' # Provides support for CORS
 gem 'graphql' # Ruby implementation of GraphQL
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,8 +172,6 @@ GEM
       faraday (>= 0.8)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.1.0)
-    fast_jsonapi (1.5)
-      activesupport (>= 4.2)
     ffaker (2.18.0)
     ffi (1.15.1)
     figaro (1.2.0)
@@ -197,6 +195,8 @@ GEM
     json_matchers (0.11.1)
       json_schema
     json_schema (0.21.0)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -471,7 +471,6 @@ DEPENDENCIES
   devise
   doorkeeper
   fabrication
-  fast_jsonapi
   ffaker
   figaro
   foreman
@@ -479,6 +478,7 @@ DEPENDENCIES
   i18n-js (= 3.5.1)
   inline_svg
   json_matchers
+  jsonapi-serializer
   letter_opener
   listen (= 3.1.5)
   mini_magick

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationSerializer
-  include FastJsonapi::ObjectSerializer
+  include JSONAPI::Serializer
   include Lookup
 end


### PR DESCRIPTION
Resolve #57 

## What happened
Migrate from [fast_jsonapi](https://github.com/Netflix/fast_jsonapi) to [jsonapi-serializer](https://github.com/jsonapi-serializer/jsonapi-serializer)

 
## Insight
Follow [migration documentation](https://github.com/jsonapi-serializer/jsonapi-serializer#migrating-from-netflixfast_jsonapi)

## Proof Of Work
Tests should be passed
 