### PR TITLE
Fix: Value Type of Identification in API Response

### DIFF
--- a/app/controllers/concerns/api/v1/error_handler.rb
+++ b/app/controllers/concerns/api/v1/error_handler.rb
@@ -19,11 +19,13 @@ module API
       def build_errors(detail:, source: nil, meta: nil, code: nil)
         [
           {
-            source: source,
+            source: {
+              parameter: source
+            }.compact,
             detail: detail,
             code: code,
             meta: meta
-          }.compact
+          }.delete_if { |_, value| value.blank? }
         ]
       end
     end

--- a/app/controllers/concerns/api/v1/error_handler.rb
+++ b/app/controllers/concerns/api/v1/error_handler.rb
@@ -19,9 +19,7 @@ module API
       def build_errors(detail:, source: nil, meta: nil, code: nil)
         [
           {
-            source: {
-              parameter: source
-            }.compact,
+            source: { parameter: source }.compact,
             detail: detail,
             code: code,
             meta: meta

--- a/app/models/concerns/associations.rb
+++ b/app/models/concerns/associations.rb
@@ -30,7 +30,7 @@ module Associations
       # To prevent `class_attribute` to override value on parent class, use merge to write the Hash-based attribute
       # https://apidock.com/rails/Class/class_attribute#1332-To-use-class-attribute-with-a-hash
       # :reek:LongParameterList { max_params: 5 }
-      def association(name, klass:, type: ActiveModel::Type::Value.new, relation:, **options)
+      def association(name, klass:, relation:, type: ActiveModel::Type::Value.new, **options)
         attribute(name, type, **options)
         self.associations = associations.merge(name => klass)
         relation_associations = public_send("#{relation}_associations").merge(name => klass)

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -29,9 +29,7 @@ class Survey < ApplicationModel
 
   class << self
     def all
-      @all ||= begin
-        JSON.parse(File.read(Rails.root.join('lib', 'assets', 'surveys.json'))).map(&method(:new))
-      end
+      @all ||= JSON.parse(File.read(Rails.root.join('lib', 'assets', 'surveys.json'))).map(&method(:new))
     end
 
     def where(attributes = {})

--- a/lib/doorkeeper/custom_error_response.rb
+++ b/lib/doorkeeper/custom_error_response.rb
@@ -6,9 +6,7 @@ module Doorkeeper
       {
         errors: [
           {
-            source: {
-              parameter: @error.class.name
-            },
+            source: { parameter: @error.class.name },
             detail: description,
             code: name
           }.compact

--- a/lib/doorkeeper/custom_error_response.rb
+++ b/lib/doorkeeper/custom_error_response.rb
@@ -6,7 +6,9 @@ module Doorkeeper
       {
         errors: [
           {
-            source: @error.class.name,
+            source: {
+              parameter: @error.class.name
+            },
             detail: description,
             code: name
           }.compact

--- a/lib/doorkeeper/custom_token_response.rb
+++ b/lib/doorkeeper/custom_token_response.rb
@@ -5,7 +5,7 @@ module Doorkeeper
     def body
       {
         data: {
-          id: @token.id,
+          id: @token.id.to_s,
           type: 'token',
           attributes: super
         }

--- a/spec/controllers/api/v1/tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/tokens_controller_spec.rb
@@ -3,6 +3,113 @@
 require 'rails_helper'
 
 RSpec.describe API::V1::TokensController, type: :controller do
+  describe 'POST#create' do
+    context 'given a valid oauth application' do
+      context 'given valid user credentials' do
+        it 'returns success status' do
+          application = Fabricate(:application)
+          user = Fabricate(:user, email: 'dev@nimblehq.co', password: '12345678')
+
+          params = {
+            grant_type: 'password',
+            email: 'dev@nimblehq.co',
+            password: '12345678'
+          }.merge(oauth_application_params(application))
+
+          post :create, params: params
+
+          expect(response).to have_http_status(:success)
+        end
+
+        it 'returns an empty response' do
+          application = Fabricate(:application)
+          user = Fabricate(:user, email: 'dev@nimblehq.co', password: '12345678')
+
+          params = {
+            grant_type: 'password',
+            email: 'dev@nimblehq.co',
+            password: '12345678'
+          }.merge(oauth_application_params(application))
+
+          post :create, params: params
+
+          response_body = JSON.parse(response.body)
+          expect(response_body).to match_json_schema('v1/tokens/create/valid')
+        end
+      end
+
+      context 'given invalid user credentials' do
+        it 'returns bad_request status' do
+          application = Fabricate(:application)
+
+          params = {
+            grant_type: 'password',
+            email: 'dev@nimblehq.co',
+            password: '12345678'
+          }.merge(oauth_application_params(application))
+
+          post :create, params: params
+
+          expect(response).to have_http_status(:bad_request)
+        end
+
+        it 'returns an empty response' do
+          application = Fabricate(:application)
+
+          params = {
+            grant_type: 'password',
+            email: 'dev@nimblehq.co',
+            password: '12345678'
+          }.merge(oauth_application_params(application))
+
+          post :create, params: params
+
+          response_body = JSON.parse(response.body)
+          expect(response_body).to match_json_schema('v1/tokens/create/invalid')
+        end
+      end
+    end
+
+    context 'given an invalid oauth application' do
+      it 'returns unauthorized status' do
+        user = Fabricate(:user, email: 'dev@nimblehq.co', password: '12345678')
+
+        params = {
+          grant_type: 'password',
+          email: 'dev@nimblehq.co',
+          password: '12345678'
+        }
+
+        post :create, params: params
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns an error message' do
+        user = Fabricate(:user, email: 'dev@nimblehq.co', password: '12345678')
+
+        params = {
+          grant_type: 'password',
+          email: 'dev@nimblehq.co',
+          password: '12345678'
+        }
+
+        post :create, params: params
+
+        expected_response = {
+          errors: [
+            {
+              code: 'invalid_client',
+              detail: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.',
+              source: 'Doorkeeper::OAuth::Error'
+            }
+          ]
+        }
+        expect(JSON.parse(response.body, symbolize_names: true)).to eq(expected_response)
+      end
+    end
+  end
+
   describe 'POST#revoke' do
     context 'given a valid oauth application' do
       it 'returns success status' do

--- a/spec/controllers/api/v1/tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/tokens_controller_spec.rb
@@ -101,7 +101,9 @@ RSpec.describe API::V1::TokensController, type: :controller do
             {
               code: 'invalid_client',
               detail: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.',
-              source: 'Doorkeeper::OAuth::Error'
+              source: {
+                parameter: 'Doorkeeper::OAuth::Error'
+              }
             }
           ]
         }

--- a/spec/controllers/api/v1/tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/tokens_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe API::V1::TokensController, type: :controller do
       context 'given valid user credentials' do
         it 'returns success status' do
           application = Fabricate(:application)
-          user = Fabricate(:user, email: 'dev@nimblehq.co', password: '12345678')
+          Fabricate(:user, email: 'dev@nimblehq.co', password: '12345678')
 
           params = {
             grant_type: 'password',
@@ -23,7 +23,7 @@ RSpec.describe API::V1::TokensController, type: :controller do
 
         it 'returns an empty response' do
           application = Fabricate(:application)
-          user = Fabricate(:user, email: 'dev@nimblehq.co', password: '12345678')
+          Fabricate(:user, email: 'dev@nimblehq.co', password: '12345678')
 
           params = {
             grant_type: 'password',
@@ -72,7 +72,7 @@ RSpec.describe API::V1::TokensController, type: :controller do
 
     context 'given an invalid oauth application' do
       it 'returns unauthorized status' do
-        user = Fabricate(:user, email: 'dev@nimblehq.co', password: '12345678')
+        Fabricate(:user, email: 'dev@nimblehq.co', password: '12345678')
 
         params = {
           grant_type: 'password',
@@ -86,7 +86,7 @@ RSpec.describe API::V1::TokensController, type: :controller do
       end
 
       it 'returns an error message' do
-        user = Fabricate(:user, email: 'dev@nimblehq.co', password: '12345678')
+        Fabricate(:user, email: 'dev@nimblehq.co', password: '12345678')
 
         params = {
           grant_type: 'password',

--- a/spec/support/api/schemas/v1/tokens/create/invalid.json
+++ b/spec/support/api/schemas/v1/tokens/create/invalid.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "errors": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "source": {
+              "type": "string"
+            },
+            "detail": {
+              "type": "string"
+            },
+            "code": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "source",
+            "detail",
+            "code"
+          ]
+        }
+      ]
+    }
+  },
+  "required": [
+    "errors"
+  ]
+}

--- a/spec/support/api/schemas/v1/tokens/create/invalid.json
+++ b/spec/support/api/schemas/v1/tokens/create/invalid.json
@@ -9,7 +9,12 @@
           "type": "object",
           "properties": {
             "source": {
-              "type": "string"
+              "type": "object",
+              "properties": {
+                "parameter": {
+                  "type": "string"
+                }
+              }
             },
             "detail": {
               "type": "string"

--- a/spec/support/api/schemas/v1/tokens/create/valid.json
+++ b/spec/support/api/schemas/v1/tokens/create/valid.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "access_token": {
+              "type": "string"
+            },
+            "token_type": {
+              "type": "string"
+            },
+            "expires_in": {
+              "type": "integer"
+            },
+            "refresh_token": {
+              "type": "string"
+            },
+            "created_at": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "access_token",
+            "token_type",
+            "expires_in",
+            "refresh_token",
+            "created_at"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ]
+    }
+  },
+  "required": [
+    "data"
+  ]
+}


### PR DESCRIPTION
Resolve #58 

## What happened
Fix: Value Type of Identification in API Response

 
## Insight
Change the custom response of Doorkeeper token API

## Proof Of Work
The response would be like this:
```json
{
    "data": {
        "id": "5",
        "type": "token",
        "attributes": {
            "access_token": "93N1shlgeZn4fFwmYiSMWPNV-42WuhA5vuPMmIem2Ik",
            "token_type": "Bearer",
            "expires_in": 7200,
            "refresh_token": "iJ3G_pKCJioyDw22zfFBYp2ExVRd8Vt0lGtKNgjNWvM",
            "created_at": 1623987725
        }
    }
}
```
 