### PR TITLE
Add name to registration form

### DIFF
--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -5,6 +5,8 @@ module API
     class RegistrationsController < Devise::RegistrationsController
       include API::V1::OauthApplicationVerifiable
 
+      before_action :configure_permitted_parameters, if: :devise_controller?
+
       def create
         super do |user|
           if user.persisted?
@@ -16,6 +18,12 @@ module API
           # Skip devise's response
           return
         end
+      end
+
+      protected
+
+      def configure_permitted_parameters
+        devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
       end
     end
   end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -4,6 +4,7 @@ module Types
   class UserType < Types::Base::Object
     field :id, ID, null: false
     field :email, String, null: false
+    field :name, String, null: false
     field :avatar_url, String, null: false
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,6 @@ class User < ApplicationRecord
   has_many :access_tokens,
            class_name: 'Doorkeeper::AccessToken',
            foreign_key: :resource_owner_id,
-           inverse_of: :resource_owner,
            dependent: :delete_all
 
   delegate :avatar_url, to: :user_decorator
@@ -16,6 +15,10 @@ class User < ApplicationRecord
   def valid_attribute?(attribute_name)
     valid?
     errors[attribute_name].blank?
+  end
+
+  def name
+    self[:name].presence || Mail::Address.new(email).local.humanize
   end
 
   private

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class UserSerializer < ApplicationSerializer
-  attributes :email, :avatar_url
+  attributes :email, :name, :avatar_url
 end

--- a/db/migrate/20210618041839_add_name_to_users.rb
+++ b/db/migrate/20210618041839_add_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddNameToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_10_040352) do
+ActiveRecord::Schema.define(version: 2021_06_18_041839) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 2021_06_10_040352) do
     t.datetime "reset_password_sent_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/support/api/schemas/v1/users/show/valid.json
+++ b/spec/support/api/schemas/v1/users/show/valid.json
@@ -17,12 +17,16 @@
             "email": {
               "type": "string"
             },
+            "name": {
+              "type": "string"
+            },
             "avatar_url": {
               "type": "string"
             }
           },
           "required": [
             "email",
+            "name",
             "avatar_url"
           ]
         }


### PR DESCRIPTION
#50 

## What happened
Add name parameter to registration form and return it on responses

 
## Insight
- Add `name` column to User
- If the user has a name, return it, otherwise, return the username of user's email
- Permit `name` parameter in registration controller
- Modify serializer and GraphQL resolver

## Proof Of Work
N/A
 