### PR TITLE
Modify Answer.text to be nullable as some answers do not have text

### DIFF
--- a/app/graphql/types/answer_type.rb
+++ b/app/graphql/types/answer_type.rb
@@ -3,7 +3,7 @@
 module Types
   class AnswerType < Types::Base::Object
     field :id, ID, null: false
-    field :text, String, null: false
+    field :text, String, null: true
     field :help_text, String, null: true
     field :input_mask_placeholder, String, null: true
     field :short_text, String, null: true


### PR DESCRIPTION
Resolve #66

## What happened

Modify `Answer.text` to be nullable as some answers do not have text

 
## Insight
N/A 

## Proof Of Work
No more error
![Postman](https://user-images.githubusercontent.com/7344405/164647428-6fe4b288-68cb-4dec-a957-33e9a0408186.png)
 