### PR TITLE
[#64] Fix: Return empty string in `/responses` API

### DIFF
--- a/app/controllers/api/v1/responses_controller.rb
+++ b/app/controllers/api/v1/responses_controller.rb
@@ -7,7 +7,7 @@ module API
         response_form = ResponseForm.new(create_params.to_h)
 
         if response_form.save
-          render status: :created
+          render json: {}, status: :created
         else
           render_error(detail: response_form.errors.full_messages.to_sentence)
         end

--- a/spec/controllers/api/v1/responses_controller_spec.rb
+++ b/spec/controllers/api/v1/responses_controller_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe API::V1::ResponsesController, type: :controller do
 
         post :create, params: { survey_id: 'd5de6a8f8f5f1cfe51bc', questions: questions_ids }
 
+        response_body = JSON.parse(response.body)
         expect(response).to have_http_status(:created)
+        expect(response_body).to eq({})
       end
     end
 


### PR DESCRIPTION
Resolved #64

## What happened
Return an empty JSON object instead of the empty string in `/responses` API

 
## Insight
N/A
 

## Proof Of Work
![Postman](https://user-images.githubusercontent.com/7344405/164668389-67b10a72-e77b-4e08-befd-f3015e46bc2d.png)

 