### PR TITLE
[#49] Expose proper error message for the login API

### DIFF
--- a/app/controllers/concerns/api/v1/doorkeeper_authentication.rb
+++ b/app/controllers/concerns/api/v1/doorkeeper_authentication.rb
@@ -22,7 +22,7 @@ module API
 
         {
           json: {
-            errors: build_errors(detail: error.description, source: error.state, code: error.name)
+            errors: build_errors(detail: error.description, code: error.name)
           }
         }
       end

--- a/app/controllers/concerns/api/v1/error_handler.rb
+++ b/app/controllers/concerns/api/v1/error_handler.rb
@@ -9,17 +9,16 @@ module API
 
       # Render Error Message in json_api format
       # :reek:LongParameterList { max_params: 5 }
-      def render_error(detail:, source: nil, meta: nil, status: :unprocessable_entity, code: nil)
-        errors = build_errors(detail: detail, source: source, meta: meta, code: code)
+      def render_error(detail:, meta: nil, status: :unprocessable_entity, code: nil)
+        errors = build_errors(detail: detail, meta: meta, code: code)
 
         render json: { errors: errors }, status: status
       end
 
       # :reek:LongParameterList { max_params: 4 }
-      def build_errors(detail:, source: nil, meta: nil, code: nil)
+      def build_errors(detail:, meta: nil, code: nil)
         [
           {
-            source: { parameter: source }.compact,
             detail: detail,
             code: code,
             meta: meta

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -2,6 +2,7 @@
 
 require 'doorkeeper/custom_token_response'
 require 'doorkeeper/custom_error_response'
+require 'doorkeeper/request/custom_password'
 
 Doorkeeper.configure do
   # Change the ORM that doorkeeper will use (requires ORM extensions installed).
@@ -507,3 +508,8 @@ end
 
 Doorkeeper::OAuth::TokenResponse.send :prepend, Doorkeeper::CustomTokenResponse
 Doorkeeper::OAuth::ErrorResponse.send :prepend, Doorkeeper::CustomErrorResponse
+Doorkeeper::GrantFlow.register(
+  :password,
+  grant_type_matches: "password",
+  grant_type_strategy: Doorkeeper::Request::CustomPassword,
+)

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -115,6 +115,7 @@ en:
         invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
         invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
         unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
+        invalid_email_or_password: 'Your email or password is incorrect. Please try again.'
 
         invalid_token:
           revoked: "The access token was revoked"

--- a/lib/doorkeeper/custom_error_response.rb
+++ b/lib/doorkeeper/custom_error_response.rb
@@ -6,7 +6,6 @@ module Doorkeeper
       {
         errors: [
           {
-            source: { parameter: @error.class.name },
             detail: description,
             code: name
           }.compact

--- a/lib/doorkeeper/oauth/custom_password_access_token_request.rb
+++ b/lib/doorkeeper/oauth/custom_password_access_token_request.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module OAuth
+    class CustomPasswordAccessTokenRequest < PasswordAccessTokenRequest
+      validate :client, error: :invalid_client
+      validate :resource_owner, error: :invalid_email_or_password
+      validate :password, error: :invalid_email_or_password
+
+      private
+
+      def validate_client
+        client.present?
+      end
+
+      def validate_password
+        is_valid_password = resource_owner.valid_password?(parameters[:password])
+        return true if is_valid_password
+
+        # Use the Devise Lockable method to increase the failed_attempts
+        resource_owner.valid_for_authentication? { is_valid_password }
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/request/custom_password.rb
+++ b/lib/doorkeeper/request/custom_password.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'doorkeeper/oauth/custom_password_access_token_request'
+
+module Doorkeeper
+  module Request
+    class CustomPassword < Password
+      def request
+        @request ||= OAuth::CustomPasswordAccessTokenRequest.new(
+          Doorkeeper.configuration,
+          client,
+          credentials,
+          resource_owner,
+          parameters
+        )
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/tokens_controller_spec.rb
@@ -68,10 +68,7 @@ RSpec.describe API::V1::TokensController, type: :controller do
             errors: [
               {
                 code: 'invalid_email_or_password',
-                detail: 'Your email or password is incorrect. Please try again.',
-                source: {
-                  parameter: 'Doorkeeper::OAuth::Error'
-                }
+                detail: 'Your email or password is incorrect. Please try again.'
               }
             ]
           }
@@ -113,10 +110,7 @@ RSpec.describe API::V1::TokensController, type: :controller do
           errors: [
             {
               code: 'invalid_client',
-              detail: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.',
-              source: {
-                parameter: 'Doorkeeper::OAuth::Error'
-              }
+              detail: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
             }
           ]
         }

--- a/spec/controllers/api/v1/tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/tokens_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe API::V1::TokensController, type: :controller do
           expect(response).to have_http_status(:success)
         end
 
-        it 'returns an empty response' do
+        it 'returns correct token attributes' do
           application = Fabricate(:application)
           Fabricate(:user, email: 'dev@nimblehq.co', password: '12345678')
 
@@ -38,14 +38,14 @@ RSpec.describe API::V1::TokensController, type: :controller do
         end
       end
 
-      context 'given invalid user credentials' do
+      context 'given INCORRECT user credentials' do
         it 'returns bad_request status' do
           application = Fabricate(:application)
 
           params = {
             grant_type: 'password',
             email: 'dev@nimblehq.co',
-            password: '12345678'
+            password: 'incorrect'
           }.merge(oauth_application_params(application))
 
           post :create, params: params
@@ -53,24 +53,37 @@ RSpec.describe API::V1::TokensController, type: :controller do
           expect(response).to have_http_status(:bad_request)
         end
 
-        it 'returns an empty response' do
+        it 'returns an error message' do
           application = Fabricate(:application)
 
           params = {
             grant_type: 'password',
             email: 'dev@nimblehq.co',
-            password: '12345678'
+            password: 'incorrect'
           }.merge(oauth_application_params(application))
 
           post :create, params: params
 
-          response_body = JSON.parse(response.body)
+          expected_response = {
+            errors: [
+              {
+                code: 'invalid_email_or_password',
+                detail: 'Your email or password is incorrect. Please try again.',
+                source: {
+                  parameter: 'Doorkeeper::OAuth::Error'
+                }
+              }
+            ]
+          }
+
+          response_body = JSON.parse(response.body, symbolize_names: true)
           expect(response_body).to match_json_schema('v1/tokens/create/invalid')
+          expect(response_body).to eq(expected_response)
         end
       end
     end
 
-    context 'given an invalid oauth application' do
+    context 'given an INVALID oauth application' do
       it 'returns unauthorized status' do
         Fabricate(:user, email: 'dev@nimblehq.co', password: '12345678')
 
@@ -133,7 +146,7 @@ RSpec.describe API::V1::TokensController, type: :controller do
       end
     end
 
-    context 'given an invalid oauth application' do
+    context 'given an INVALID oauth application' do
       it 'returns forbidden status' do
         Fabricate(:access_token, token: 'access_token', application_id: Fabricate(:application).id)
 

--- a/spec/support/api/schemas/v1/tokens/create/invalid.json
+++ b/spec/support/api/schemas/v1/tokens/create/invalid.json
@@ -8,14 +8,6 @@
         {
           "type": "object",
           "properties": {
-            "source": {
-              "type": "object",
-              "properties": {
-                "parameter": {
-                  "type": "string"
-                }
-              }
-            },
             "detail": {
               "type": "string"
             },
@@ -24,7 +16,6 @@
             }
           },
           "required": [
-            "source",
             "detail",
             "code"
           ]


### PR DESCRIPTION
Resolve #49

## What happened

- Customize password grant flow to return the correct error message.
- Create the custom classes and re-register the grant flow.
- Fix tests

 
## Insight

N/A
 

## Proof Of Work

![Postman](https://user-images.githubusercontent.com/7344405/165077779-813dee3d-1b7c-4612-9bf9-0bf2c5cd624a.png)
