### PR TITLE
[#70] Survey list API should not return the question id list relationships

### DIFF
--- a/app/controllers/api/v1/surveys_controller.rb
+++ b/app/controllers/api/v1/surveys_controller.rb
@@ -8,7 +8,7 @@ module API
       def index
         pagy, surveys = pagy_array(Survey.all, pagination_params)
 
-        render json: SurveyListSerializer.new(surveys, meta: meta_from_pagy(pagy))
+        render json: SurveySimpleSerializer.new(surveys, meta: meta_from_pagy(pagy))
       rescue Pagy::OverflowError
         render status: :not_found
       end

--- a/app/controllers/api/v1/surveys_controller.rb
+++ b/app/controllers/api/v1/surveys_controller.rb
@@ -8,7 +8,7 @@ module API
       def index
         pagy, surveys = pagy_array(Survey.all, pagination_params)
 
-        render json: SurveySerializer.new(surveys, meta: meta_from_pagy(pagy))
+        render json: SurveyListSerializer.new(surveys, meta: meta_from_pagy(pagy))
       rescue Pagy::OverflowError
         render status: :not_found
       end

--- a/app/serializers/survey_list_serializer.rb
+++ b/app/serializers/survey_list_serializer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SurveyListSerializer < ApplicationSerializer
+  attributes :title,
+             :description,
+             :thank_email_above_threshold,
+             :thank_email_below_threshold,
+             :is_active,
+             :cover_image_url,
+             :created_at,
+             :active_at,
+             :inactive_at
+
+  attribute :survey_type, &:type
+end

--- a/app/serializers/survey_serializer.rb
+++ b/app/serializers/survey_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class SurveySerializer < SurveyListSerializer
+class SurveySerializer < SurveySimpleSerializer
   has_many :questions
 end

--- a/app/serializers/survey_serializer.rb
+++ b/app/serializers/survey_serializer.rb
@@ -1,17 +1,5 @@
 # frozen_string_literal: true
 
-class SurveySerializer < ApplicationSerializer
-  attributes :title,
-             :description,
-             :thank_email_above_threshold,
-             :thank_email_below_threshold,
-             :is_active,
-             :cover_image_url,
-             :created_at,
-             :active_at,
-             :inactive_at
-
-  attribute :survey_type, &:type
-
+class SurveySerializer < SurveyListSerializer
   has_many :questions
 end

--- a/app/serializers/survey_simple_serializer.rb
+++ b/app/serializers/survey_simple_serializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SurveyListSerializer < ApplicationSerializer
+class SurveySimpleSerializer < ApplicationSerializer
   attributes :title,
              :description,
              :thank_email_above_threshold,

--- a/spec/support/api/schemas/v1/surveys/index/valid.json
+++ b/spec/support/api/schemas/v1/surveys/index/valid.json
@@ -107,8 +107,7 @@
         "required": [
           "id",
           "type",
-          "attributes",
-          "relationships"
+          "attributes"
         ]
       }
     },


### PR DESCRIPTION
Resolves https://github.com/nimblehq/nimble-survey-web/issues/70

## What happened

Omit the `relationships` field in the survey list API

 
## Insight

Just create a new serializer `SurveyListSerializer`
 

## Proof Of Work

|Before|After|
|------|------|
|![Postman](https://user-images.githubusercontent.com/7344405/179172961-24eb1c86-61a7-45c9-9a6c-e8b56e38086a.png)|![Postman](https://user-images.githubusercontent.com/7344405/179172874-9ac090cb-1a33-4885-8ed3-57166569ac73.png)|
 