### PR TITLE
[#80] Fix: Wrong validating logic for the submit survey responses API

### DIFF
--- a/app/forms/response_form.rb
+++ b/app/forms/response_form.rb
@@ -26,7 +26,7 @@ class ResponseForm < ApplicationForm
     survey_questions_ids = survey.questions.map(&:id)
     questions_ids = questions.pluck(:id)
 
-    return if (survey_questions_ids & questions_ids).to_set == questions_ids.to_set
+    return if (questions_ids & survey_questions_ids) == questions_ids
 
     errors.add(:questions, :invalid)
   end

--- a/app/forms/response_form.rb
+++ b/app/forms/response_form.rb
@@ -26,7 +26,7 @@ class ResponseForm < ApplicationForm
     survey_questions_ids = survey.questions.map(&:id)
     questions_ids = questions.pluck(:id)
 
-    return if (survey_questions_ids & questions_ids).difference(questions_ids).empty?
+    return if (survey_questions_ids & questions_ids).to_set == questions_ids.to_set
 
     errors.add(:questions, :invalid)
   end

--- a/app/forms/response_form.rb
+++ b/app/forms/response_form.rb
@@ -26,7 +26,7 @@ class ResponseForm < ApplicationForm
     survey_questions_ids = survey.questions.map(&:id)
     questions_ids = questions.pluck(:id)
 
-    return if (survey_questions_ids & questions_ids) == questions_ids
+    return if (survey_questions_ids & questions_ids).difference(questions_ids).empty?
 
     errors.add(:questions, :invalid)
   end

--- a/spec/forms/response_form_spec.rb
+++ b/spec/forms/response_form_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ResponseForm do
   describe '#save' do
     context 'given valid attributes' do
-      context 'given a same questions order' do
+      context 'given a questions_ids param that has the same order as questions in DB' do
         it 'returns true' do
           questions_ids = [
             { id: '940d229e4cd87cd1e202' },
@@ -28,7 +28,7 @@ RSpec.describe ResponseForm do
         end
       end
 
-      context 'given a different questions order' do
+      context 'given a questions_ids param that has a different order as questions in DB' do
         it 'returns true' do
           questions_ids = [
             { id: 'c3a9b8ce5c2356010703' },

--- a/spec/forms/response_form_spec.rb
+++ b/spec/forms/response_form_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe ResponseForm do
   describe '#save' do
     context 'given valid attributes' do
-
       context 'given a same questions order' do
         it 'returns true' do
           questions_ids = [
@@ -29,7 +28,7 @@ RSpec.describe ResponseForm do
         end
       end
 
-      context 'given a different questions order ' do
+      context 'given a different questions order' do
         it 'returns true' do
           questions_ids = [
             { id: 'c3a9b8ce5c2356010703' },

--- a/spec/forms/response_form_spec.rb
+++ b/spec/forms/response_form_spec.rb
@@ -5,25 +5,51 @@ require 'rails_helper'
 RSpec.describe ResponseForm do
   describe '#save' do
     context 'given valid attributes' do
-      it 'returns true' do
-        questions_ids = [
-          { id: '940d229e4cd87cd1e202' },
-          { id: 'c3a9b8ce5c2356010703' }
-        ]
-        form = described_class.new(survey_id: 'd5de6a8f8f5f1cfe51bc', questions: questions_ids)
 
-        expect(form.save).to eq(true)
+      context 'given a same questions order' do
+        it 'returns true' do
+          questions_ids = [
+            { id: '940d229e4cd87cd1e202' },
+            { id: 'c3a9b8ce5c2356010703' }
+          ]
+          form = described_class.new(survey_id: 'd5de6a8f8f5f1cfe51bc', questions: questions_ids)
+
+          expect(form.save).to eq(true)
+        end
+
+        it 'does NOT have errors' do
+          questions_ids = [
+            { id: '940d229e4cd87cd1e202' },
+            { id: 'c3a9b8ce5c2356010703' }
+          ]
+          form = described_class.new(survey_id: 'd5de6a8f8f5f1cfe51bc', questions: questions_ids)
+          form.save
+
+          expect(form.errors).to be_empty
+        end
       end
 
-      it 'does NOT have errors' do
-        questions_ids = [
-          { id: '940d229e4cd87cd1e202' },
-          { id: 'c3a9b8ce5c2356010703' }
-        ]
-        form = described_class.new(survey_id: 'd5de6a8f8f5f1cfe51bc', questions: questions_ids)
-        form.save
+      context 'given a different questions order ' do
+        it 'returns true' do
+          questions_ids = [
+            { id: 'c3a9b8ce5c2356010703' },
+            { id: '940d229e4cd87cd1e202' }
+          ]
+          form = described_class.new(survey_id: 'd5de6a8f8f5f1cfe51bc', questions: questions_ids)
 
-        expect(form.errors).to be_empty
+          expect(form.save).to eq(true)
+        end
+
+        it 'does NOT have errors' do
+          questions_ids = [
+            { id: 'c3a9b8ce5c2356010703' },
+            { id: '940d229e4cd87cd1e202' }
+          ]
+          form = described_class.new(survey_id: 'd5de6a8f8f5f1cfe51bc', questions: questions_ids)
+          form.save
+
+          expect(form.errors).to be_empty
+        end
       end
     end
 


### PR DESCRIPTION
- Resolves #80

## What happened 👀

For the submitting survey responses API, with our validating logic, we did not allow submitting questions with different orders. I updated the logic to support it.

## Insight 📝

The order of array when using intersection can affect the result. 

`(a & b) == b` is different with `(b & a) == b`

## Proof Of Work 📹

When I added tests with questions that have different orders:

![Screenshot 2023-01-13 at 14 26 40](https://user-images.githubusercontent.com/19943832/212271543-3221e655-a600-4835-b658-284d2609942e.png)

All tests are passed:

![Screenshot 2023-01-13 at 14 58 14](https://user-images.githubusercontent.com/19943832/212271578-ee9e71e1-2a81-4e99-8a87-814ca3386547.png)
