### PR TITLE
Add Prism to create mocking server

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,6 +31,15 @@ services:
     environment:
       - SWAGGER_JSON=/docs/openapi/openapi.yml
 
+  prism:
+    image: stoplight/prism:4
+    container_name: nimble_survey_web_prism
+    command: 'mock -h 0.0.0.0 /docs/openapi/openapi.yml'
+    volumes:
+      - ./docs:/docs
+    ports:
+      - "4010:4010"
+
 volumes:
   postgres_data:
   redis_data:

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -6,9 +6,9 @@ info:
   version: 1.0.0
 
 servers:
-  - url: https://survey-api-staging.nimblehq.co
+  - url: https://survey-api-staging.nimblehq.co/api/v1
     description: Staging server
-  - url: https://survey-api.nimblehq.co
+  - url: https://survey-api.nimblehq.co/api/v1
     description: Production server
 
 security:
@@ -21,5 +21,5 @@ components:
       scheme: bearer
 
 paths:
-  /api/v1/oauth/token:
+  /oauth/token:
     $ref: "paths/oauth/post_login_email.yml"

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -6,16 +6,10 @@ info:
   version: 1.0.0
 
 servers:
-  - url: '{base_url}'
-    variables:
-      base_url:
-        default: survey-api.nimblehq.co     # Production server
-        enum:
-          - http://localhost:3000                       # Development server
-          - http://localhost:4010                       # Mock Development server
-          - https://survey-api-staging.nimblehq.co      # Staging server
-          - https://survey-api-staging.nimblehq.co:4010 # Mock Staging server
-          - https://survey-api.nimblehq.co              # Production server
+  - url: https://survey-api-staging.nimblehq.co
+    description: Staging server
+  - url: https://survey-api.nimblehq.co
+    description: Production server
 
 security:
   - bearerAuth: []

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -6,14 +6,16 @@ info:
   version: 1.0.0
 
 servers:
-  - url: https://{base_url}/api/v1
+  - url: '{base_url}'
     variables:
       base_url:
         default: survey-api.nimblehq.co     # Production server
         enum:
-          - localhost:3000                  # Development server
-          - survey-api-staging.nimblehq.co  # Staging server
-          - survey-api.nimblehq.co          # Production server
+          - http://localhost:3000                       # Development server
+          - http://localhost:4010                       # Mock Development server
+          - https://survey-api-staging.nimblehq.co      # Staging server
+          - https://survey-api-staging.nimblehq.co:4010 # Mock Staging server
+          - https://survey-api.nimblehq.co              # Production server
 
 security:
   - bearerAuth: []
@@ -25,5 +27,5 @@ components:
       scheme: bearer
 
 paths:
-  /oauth/token:
+  /api/v1/oauth/token:
     $ref: "paths/oauth/post_login_email.yml"


### PR DESCRIPTION
## What happened 👀

Add service `prism` to docker-compose

## Insight 📝

We are going to use https://github.com/stoplightio/prism to support mocking server in a different port (4010)

## Proof Of Work 📹

<img width="921" alt="Screenshot 2023-06-08 at 16 53 15" src="https://github.com/nimblehq/nimble-survey-web/assets/19943832/6d881f2b-2a35-4f01-a60c-bc59655444d7">

