### PR TITLE
Add Logout API documentation

### DIFF
--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -21,6 +21,8 @@ components:
       scheme: bearer
   schemas:
     $ref: "schemas.yml"
+  responses:
+    $ref: "responses.yml"
 
 paths:
   /registrations:
@@ -28,6 +30,9 @@ paths:
 
   /oauth/token:
     $ref: "paths/oauth/post_token.yml"
+
+  /oauth/revoke:
+    $ref: "paths/oauth/post_revoke.yml"
 
   /surveys:
     $ref: "paths/surveys/get_survey_list.yml"

--- a/docs/openapi/paths/oauth/post_revoke.yml
+++ b/docs/openapi/paths/oauth/post_revoke.yml
@@ -1,0 +1,21 @@
+---
+post:
+  tags:
+    - Authentication
+  security: []
+  summary: Logout
+  description: Revoke the access token.
+  requestBody:
+    required: true
+    description: A request body for revoking the access token.
+    content:
+      application/json:
+        schema:
+          $ref: '../../schemas.yml#/requests_oauth_post_revoke'
+
+  responses:
+    '200':
+      description: OK
+
+    default:
+      $ref: '../../responses.yml#/responses_default_error'

--- a/docs/openapi/paths/oauth/post_token.yml
+++ b/docs/openapi/paths/oauth/post_token.yml
@@ -32,12 +32,4 @@ post:
             $ref: '../../schemas.yml#/responses_oauth_post_token'
 
     default:
-      description: Error
-      content:
-        application/json:
-          example:
-            errors:
-              - code: 'invalid_request'
-                detail: 'The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed.'
-          schema:
-            $ref: '../../schemas.yml#/error'
+      $ref: '../../responses.yml#/responses_default_error'

--- a/docs/openapi/paths/registrations/post_create.yml
+++ b/docs/openapi/paths/registrations/post_create.yml
@@ -20,12 +20,4 @@ post:
       description: Created
 
     default:
-      description: Error
-      content:
-        application/json:
-          example:
-            errors:
-              - code: 'invalid_request'
-                detail: 'The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed.'
-          schema:
-            $ref: '../../schemas.yml#/error'
+      $ref: '../../responses.yml#/responses_default_error'

--- a/docs/openapi/paths/surveys/get_survey_list.yml
+++ b/docs/openapi/paths/surveys/get_survey_list.yml
@@ -29,13 +29,6 @@ get:
             $ref: '../../schemas.yml#/responses_surveys_get_survey_list'
           examples:
             $ref: 'get_survey_list_examples.json'
+
     default:
-      description: Error
-      content:
-        application/json:
-          example:
-            errors:
-              - code: 'invalid_request'
-                detail: 'The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed.'
-          schema:
-            $ref: '../../schemas.yml#/error'
+      $ref: '../../responses.yml#/responses_default_error'

--- a/docs/openapi/responses.yml
+++ b/docs/openapi/responses.yml
@@ -1,0 +1,4 @@
+---
+
+responses_default_error:
+  $ref: "responses/error/default.yml"

--- a/docs/openapi/responses/error/default.yml
+++ b/docs/openapi/responses/error/default.yml
@@ -1,0 +1,11 @@
+---
+description: Default Error
+
+content:
+  application/json:
+    schema:
+      $ref: '../../schemas.yml#/error'
+    example:
+      errors:
+        - code: 'invalid_request'
+          detail: 'The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed.'

--- a/docs/openapi/schemas.yml
+++ b/docs/openapi/schemas.yml
@@ -7,6 +7,9 @@ requests_oauth_post_login_email:
 requests_oauth_post_refresh_token:
   $ref: "schemas/requests/oauth/post_refresh_token.yml"
 
+requests_oauth_post_revoke:
+  $ref: "schemas/requests/oauth/post_revoke.yml"
+
 requests_registrations_post_create:
   $ref: "schemas/requests/registrations/post_create.yml"
 

--- a/docs/openapi/schemas/requests/oauth/post_revoke.yml
+++ b/docs/openapi/schemas/requests/oauth/post_revoke.yml
@@ -1,0 +1,24 @@
+---
+type: object
+
+description: |-
+  A request body for refresh a new token
+
+required:
+  - token
+  - client_id
+  - client_secret
+
+properties:
+  token:
+    type: string
+    description: The current access token.
+    example: t9KR8HoiJXZfdfs5vVB1PKwjg7m7ynvXBrUkpUyxYkU
+  client_id:
+    type: string
+    description: The Client ID of the application requesting an access token.
+    example: ly1nj6n11vionaie65emwzk575hnnmrk
+  client_secret:
+    type: string
+    description: The client secret of the application requesting an access token.
+    example: hOzsTeFlT6ko0dme22uGbQal04SBPYc1


### PR DESCRIPTION
## What happened 👀

- Added logout API doc
- Added `responses.yml` to reuse the error default response body.

## Insight 📝

An improvement in this pull request is creating `responses.yml` to support the reusability of response bodies (not schema)

## Proof Of Work 📹

![Screenshot 2023-06-23 at 15 01 56](https://github.com/nimblehq/nimble-survey-web/assets/19943832/e2a50f57-784f-48f9-851d-cf699caf6b13)

