### PR TITLE
Setup Mock Server with Prism

### DIFF
--- a/.github/workflows/mock_deploy.yml
+++ b/.github/workflows/mock_deploy.yml
@@ -1,0 +1,22 @@
+name: Mock Deploy
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  deploy:
+    name: Deploy server mock
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to fly
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile.mock
+++ b/Dockerfile.mock
@@ -1,0 +1,7 @@
+FROM stoplight/prism:latest
+
+COPY /docs /usr/src/prism/packages/cli/docs/
+
+EXPOSE 80
+
+CMD ["mock", "-h", "0.0.0.0", "-p", "80", "docs/openapi/openapi.yml"]

--- a/docs/openapi/openapi.yml
+++ b/docs/openapi/openapi.yml
@@ -10,6 +10,8 @@ servers:
     description: Staging server
   - url: https://survey-api.nimblehq.co/api/v1
     description: Production server
+  - url: https://nimble-survey-web-mock.fly.dev
+    description: Mock server
 
 security:
   - BearerAuth: []

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,18 @@
+# fly.toml app configuration file generated for nimble-survey-web-mock on 2023-07-06T16:37:17+07:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "nimble-survey-web-mock"
+primary_region = "sin"
+
+[build]
+  dockerfile = "Dockerfile.mock"
+
+[http_service]
+  internal_port = 80
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]


### PR DESCRIPTION
## What happened 👀

- Created a new workflow to deploy a mock server to fly.io
- Created a new Dockerfile (`Dockerfile.mock`)
- Generate `fly.toml` to configure a server with fly.io

## Insight 📝

- I used `fly cli` to generate the `fly.toml` file and deploy it with `FLY_API_TOKEN`.
- The base URL of the mock server: https://nimble-survey-web-mock.fly.dev/

## Proof Of Work 📹

![Screenshot 2023-07-21 at 10 54 57](https://github.com/nimblehq/nimble-survey-web/assets/19943832/ddb42186-8b84-4316-bef1-87eaf95b25aa)

