### PR TITLE
[#105] Fix: Unable to find latest point release version for 115.0.5790

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ group :test do
   gem 'rspec-rails', '>=4.0.0.beta2' # Rails testing engine
   gem 'rspec-retry' # Retry randomly failing rspec example.
   gem 'capybara', '>= 2.15' # Integration testing
-  gem 'webdrivers' # Run Selenium tests more easily with automatic installation and updates for all supported webdrivers
+  gem 'selenium-webdriver' # Ruby bindings for Selenium
   gem 'database_cleaner' # Use Database Cleaner
   gem 'shoulda-matchers' # Tests common Rails functionalities
   gem 'json_matchers' # Validate the JSON returned by your Rails JSON APIs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.3)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     awesome_print (1.9.2)
@@ -85,7 +85,7 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
-    capybara (3.39.0)
+    capybara (3.39.2)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -244,11 +244,11 @@ GEM
       net-protocol
     nio4r (2.5.9)
     no_proxy_fix (0.1.2)
-    nokogiri (1.14.2-arm64-darwin)
+    nokogiri (1.15.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.2-x86_64-darwin)
+    nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.2-x86_64-linux)
+    nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
     octokit (5.6.1)
       faraday (>= 1, < 3)
@@ -268,13 +268,13 @@ GEM
       pry (>= 0.13, < 0.15)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     puma (6.2.1)
       nio4r (~> 2.0)
     pundit (2.3.0)
       activesupport (>= 3.0.0)
-    racc (1.6.2)
-    rack (2.2.6.4)
+    racc (1.7.1)
+    rack (2.2.7)
     rack-cors (2.0.1)
       rack (>= 2.0.0)
     rack-test (2.1.0)
@@ -326,7 +326,7 @@ GEM
       kwalify (~> 0.7.0)
       parser (~> 3.2.0)
       rainbow (>= 2.0, < 4.0)
-    regexp_parser (2.7.0)
+    regexp_parser (2.8.1)
     require_all (3.0.0)
     responders (3.1.0)
       actionpack (>= 5.2)
@@ -379,7 +379,7 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    selenium-webdriver (4.8.6)
+    selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -433,10 +433,6 @@ GEM
     vcr (6.1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -501,6 +497,7 @@ DEPENDENCIES
   rspec-retry
   rubocop
   rubocop-rails
+  selenium-webdriver
   shoulda-matchers
   sidekiq
   simplecov
@@ -513,7 +510,6 @@ DEPENDENCIES
   timecop
   tzinfo-data
   vcr
-  webdrivers
   webmock
 
 RUBY VERSION


### PR DESCRIPTION
- Close #105

## What happened 👀

- Remove the `webdrivers` gem and just use the `selenium-webdriver` as Capybara only needs that
- Update capybara gem version

## Insight 📝

N/A

## Proof Of Work 📹

It works 🎉 
No more errors
https://github.com/nimblehq/nimble-survey-web/actions/runs/5646894751?pr=106
